### PR TITLE
TASK-201: Formalize cross-sender mailbox ordering guarantees

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,9 +20,14 @@ An actor is addressed only through an `ActorRef<T>` — a stable, thread-safe ha
   below).
 * **Per-actor ordering:** messages sent by a single thread to a single actor are delivered in
   the order they were sent (the mailbox is FIFO).
-* **Cross-sender ordering is not guaranteed:** if two different threads each call `tell()` on
-  the same actor concurrently, the relative order in which their messages are enqueued is not
-  specified. Full ordering guarantees are formalized in M2 (TASK-201).
+* **Cross-sender causal ordering (TASK-201):** if `tell(A)` returns before `tell(B)` is called on
+  the same actor, and that ordering is established by real synchronization between the calling
+  threads, `A` is delivered before `B`. Two `tell()` calls with no happens-before relationship
+  between them have unspecified relative order — this is inherent to concurrency, not a gap. See
+  `docs/decisions/ADR-003-cross-sender-mailbox-ordering.md`.
+* **Backpressure admission order (TASK-201):** when the mailbox is full, senders blocked in
+  `tell()` are admitted in the order they began waiting (FIFO) once space frees up; a sender that
+  arrives later cannot jump ahead of one that is already blocked.
 
 ## 3. Concurrency guarantees
 

--- a/docs/decisions/ADR-003-cross-sender-mailbox-ordering.md
+++ b/docs/decisions/ADR-003-cross-sender-mailbox-ordering.md
@@ -1,0 +1,70 @@
+# ADR-003: Cross-sender mailbox ordering guarantees
+
+* Status: Accepted
+* Written during: M2 (TASK-201)
+
+## Context
+
+M1 guarantees per-sender ordering: messages sent by a single thread to a single actor are
+delivered in the order they were sent, because the mailbox is FIFO and a single sender thread's
+calls are naturally sequential. It leaves cross-sender ordering — two different threads calling
+`tell()` on the same actor — unspecified. `docs/architecture.md` §2 flagged this gap and deferred
+resolving it to TASK-201.
+
+`Mailbox.offer()` already serializes all enqueue operations behind a single lock, which gives a
+real ordering property "for free." The open questions are (1) precisely what that property is
+safe to promise, and (2) whether backpressure (the mailbox being full) can silently break it.
+
+## Decision
+
+Two guarantees are formalized:
+
+1. **Causal (happens-before) ordering.** If `tell(A)` returns before `tell(B)` is called on the
+   same actor, and that ordering is established by real synchronization between the two calling
+   threads (not just coincidental timing), then `A` is delivered before `B`. This falls directly
+   out of `offer()`'s single lock: enqueueing is a synchronization action, so if a happens-before
+   relationship exists between two `tell()` calls, the Java Memory Model guarantees the first
+   call's enqueue completes (and is visible) before the second call's enqueue can begin.
+   Two `tell()` calls with **no** happens-before relationship between them — genuinely racing
+   threads — have unspecified relative order. This is not a limitation to work around; "first" is
+   not a meaningful concept for two calls with no synchronization tying them together, in this or
+   any framework.
+
+2. **Backpressure admission order.** When the mailbox is full, senders blocked in `offer()` are
+   admitted in the order they began waiting (FIFO) once space frees up. A sender that arrives
+   after another is already blocked cannot jump ahead of it.
+
+Guarantee (1) already holds today and requires no implementation change. Guarantee (2) does not:
+`Mailbox` currently uses a non-fair `ReentrantLock`. `Condition.signal()` already wakes blocked
+waiters in FIFO order relative to each other, but a non-fair lock lets a *new* caller barge in
+and acquire the lock — and enqueue — ahead of an already-signaled waiter that is still in the
+process of reacquiring it. The fix is to construct `Mailbox`'s lock in fair mode
+(`new ReentrantLock(true)`), which removes barging: the JDK's fair-lock contract admits threads
+in strict arrival order.
+
+## Alternatives considered
+
+* **No guarantee at all for cross-sender ordering.** Simpler to state, but throws away a property
+  the current lock-based implementation already provides, and later milestones (M4 supervision,
+  M5 ask-pattern) would have no ordering to reason about at all when composing calls across
+  actors. Rejected as strictly weaker than what's achievable at no extra cost.
+* **Strict real-time submission order** (deliver in the literal wall-clock order `tell()` was
+  invoked, even without happens-before). Not a coherent guarantee: for two threads racing with no
+  synchronization between them, "which one happened first" is not well-defined by the Java Memory
+  Model or by physics at this granularity. Achieving it would require imposing synchronization
+  the caller never asked for, for a guarantee that can't actually be honestly kept. Rejected.
+* **Leave backpressure admission order unspecified**, deferring to TASK-306's mailbox-bounds
+  revisit (M3). Rejected because it would leave a real, currently-observable gap in an otherwise
+  clean guarantee, and the fix (a fair lock) is small and self-contained; TASK-306 revisits the
+  bounds/backpressure *policy* (capacity, block-vs-reject), not this ordering property, and can
+  build on top of a fair lock either way.
+
+## Consequences
+
+* `Mailbox`'s internal lock is now fair, which trades some throughput under contention for the
+  ordering guarantee. This is acceptable for M2; TASK-306 (M3) revisits mailbox behavior with real
+  benchmark data and can reassess if fairness turns out to be a measured bottleneck.
+* `docs/architecture.md` §2 states both guarantees precisely instead of deferring to this ADR by
+  reference alone.
+* Any future change to `Mailbox`'s locking strategy must preserve both guarantees, or supersede
+  this ADR explicitly.

--- a/framework-core/src/main/java/dev/actorframework/core/Mailbox.java
+++ b/framework-core/src/main/java/dev/actorframework/core/Mailbox.java
@@ -18,6 +18,13 @@ import java.util.concurrent.locks.ReentrantLock;
  * what gives the runtime its sequential-processing guarantee (TASK-106); this class does not itself
  * enforce single-consumer usage.
  *
+ * <p><b>Cross-sender ordering (TASK-201):</b> if one {@link #offer} call returns before another
+ * begins, with a real happens-before relationship between the two callers, the first is enqueued
+ * before the second. Calls with no such relationship have unspecified relative order. When the
+ * mailbox is full, senders already blocked in {@link #offer} are admitted before a sender that
+ * arrives later, once space frees up. See {@code
+ * docs/decisions/ADR-003-cross-sender-mailbox-ordering.md}.
+ *
  * <p>Ownership: a {@code Mailbox} is owned by exactly one {@link ActorCell} for its entire lifetime
  * and is never shared between actors.
  */
@@ -28,7 +35,11 @@ final class Mailbox<T> {
 
   private final ArrayDeque<T> queue;
   private final int capacity;
-  private final ReentrantLock lock = new ReentrantLock();
+
+  // Fair (TASK-201, ADR-003): guarantees that a sender already blocked in offer() is admitted
+  // before one that arrives later, once space frees up. A non-fair lock lets a fresh caller
+  // barge ahead of an already-signaled waiter still reacquiring the lock.
+  private final ReentrantLock lock = new ReentrantLock(true);
   private final Condition notFull = lock.newCondition();
   private final Condition notEmpty = lock.newCondition();
   private boolean closed = false;

--- a/framework-core/src/test/java/dev/actorframework/core/MailboxTest.java
+++ b/framework-core/src/test/java/dev/actorframework/core/MailboxTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
@@ -118,5 +120,101 @@ class MailboxTest {
   void rejectsNonPositiveCapacity() {
     org.junit.jupiter.api.Assertions.assertThrows(
         IllegalArgumentException.class, () -> new Mailbox<String>(0));
+  }
+
+  // TASK-201 (ADR-003): cross-sender ordering guarantees.
+
+  @Test
+  void enqueuesInHappensBeforeOrderAcrossSenders() throws InterruptedException {
+    Mailbox<String> mailbox = new Mailbox<>(16);
+    CountDownLatch firstReturned = new CountDownLatch(1);
+
+    Thread sender1 =
+        new Thread(
+            () -> {
+              mailbox.offer("first");
+              firstReturned.countDown();
+            });
+    sender1.start();
+    // sender1's tell() has returned before sender2's begins: a real happens-before relationship.
+    firstReturned.await();
+
+    Thread sender2 = new Thread(() -> mailbox.offer("second"));
+    sender2.start();
+
+    sender1.join(Duration.ofSeconds(2).toMillis());
+    sender2.join(Duration.ofSeconds(2).toMillis());
+
+    assertEquals("first", mailbox.take());
+    assertEquals("second", mailbox.take());
+  }
+
+  @Test
+  void admitsASenderThatIsAlreadyBlockedBeforeALaterArrival() throws InterruptedException {
+    for (int iteration = 0; iteration < 30; iteration++) {
+      Mailbox<String> mailbox = new Mailbox<>(1);
+      assertTrue(mailbox.offer("seed"));
+
+      List<String> admissionOrder = new CopyOnWriteArrayList<>();
+      CountDownLatch earlyStarted = new CountDownLatch(1);
+      Thread early =
+          new Thread(
+              () -> {
+                earlyStarted.countDown();
+                mailbox.offer("early");
+                admissionOrder.add("early");
+              });
+      early.start();
+      earlyStarted.await();
+      waitUntilBlocked(early);
+
+      // 'late' is pre-warmed and hot-spinning on a plain volatile read, so it can attempt the
+      // lock within nanoseconds of 'go' flipping — unlike 'early', which needs a real OS-level
+      // unpark-and-reschedule to reacquire the lock after being signaled. Without that head
+      // start, thread startup latency alone lets 'early' win even with a non-fair lock, masking
+      // the barging bug this test exists to catch.
+      AtomicBoolean go = new AtomicBoolean(false);
+      CountDownLatch lateSpinning = new CountDownLatch(1);
+      Thread late =
+          new Thread(
+              () -> {
+                lateSpinning.countDown();
+                while (!go.get()) {
+                  Thread.onSpinWait();
+                }
+                mailbox.offer("late");
+                admissionOrder.add("late");
+              });
+      late.start();
+      lateSpinning.await();
+
+      assertEquals("seed", mailbox.take()); // frees the only slot; wakes 'early'
+      go.set(true); // release the already-spinning 'late' to race 'early' for that same slot
+
+      // Blocks until whichever of early/late wins the race enqueues, then frees the slot again
+      // for the loser.
+      assertTimeoutPreemptively(Duration.ofSeconds(2), mailbox::take);
+
+      early.join(Duration.ofSeconds(2).toMillis());
+      late.join(Duration.ofSeconds(2).toMillis());
+
+      assertEquals(
+          List.of("early", "late"),
+          admissionOrder,
+          "a sender already blocked must be admitted before one that arrives later (iteration "
+              + iteration
+              + ")");
+    }
+  }
+
+  private static void waitUntilBlocked(Thread thread) {
+    long deadlineNanos = System.nanoTime() + Duration.ofSeconds(2).toNanos();
+    while (thread.getState() != Thread.State.WAITING
+        && thread.getState() != Thread.State.TIMED_WAITING) {
+      if (System.nanoTime() > deadlineNanos) {
+        throw new AssertionError("thread did not block in time: " + thread.getState());
+      }
+      Thread.onSpinWait();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Formalizes two cross-sender mailbox ordering guarantees, closing TASK-201 (M2): causal (happens-before) ordering across senders to the same actor, and FIFO admission for senders blocked on a full mailbox.
- Records the decision in `docs/decisions/ADR-003-cross-sender-mailbox-ordering.md` and updates `docs/architecture.md` §2 to state both guarantees explicitly instead of deferring to "formalized in M2."
- `Mailbox`'s internal lock is now fair (`new ReentrantLock(true)`), closing a real barging gap: a non-fair lock let a fresh caller jump the queue ahead of a sender already blocked waiting for space. The happens-before guarantee already held with no code change needed.

## Test plan
- [x] New test `enqueuesInHappensBeforeOrderAcrossSenders` — asserts delivery order across two threads with an explicit happens-before hand-off.
- [x] New test `admitsASenderThatIsAlreadyBlockedBeforeALaterArrival` — TDD'd against the bug: reliably RED on the non-fair lock (confirmed via a tight race between an already-blocked sender and a pre-warmed, hot-spinning late arrival), GREEN after the fair-lock fix; verified stable across 5 full-suite reruns.
- [x] `./gradlew build` passes (includes spotless formatting check and full test suite).

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)