### PR TITLE
Document git workflow + enable branch protection on main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,13 @@ The guiding rule: **complexity is added because the application needs it, not be
 framework requires it.** Do not add features, abstractions, or configuration knobs ahead of the
 milestone that actually needs them.
 
+## Git workflow
+
+* No direct pushes to `main` — it's branch-protected (required PR, required passing CI, no force
+  pushes/deletions, enforced even for admins). Every change, including small docs fixes, goes
+  through a feature branch and a pull request.
+* CI (`.github/workflows/ci.yml`, TASK-002) must be green before a PR can merge.
+
 ## Module boundaries
 
 * `framework-core` — the actor runtime. No dependency on any other module in this repo. Keep it


### PR DESCRIPTION
## Summary
- Enables GitHub branch protection on `main`: requires a pull request before merging, requires the CI check ("Build, test, format & artifacts") to pass, enforced even for repo admins, and disallows force pushes/deletions.
- Documents this in `AGENTS.md` under a new "Git workflow" section so the rule is visible to contributors (human or agent) reading the repo's own docs, not just enforced silently by GitHub settings.

## Test plan
- [x] Verified via `gh api repos/liccioni/Former-Child-Actor/branches/main/protection` that the rule is active: `required_pull_request_reviews.required_approving_review_count: 0`, `required_status_checks.contexts: ["Build, test, format & artifacts"]`, `enforce_admins: true`, `allow_force_pushes: false`, `allow_deletions: false`.
- [x] This PR itself demonstrates the new workflow (branch + PR, no direct push to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)