### PR TITLE
TASK-207: Java Memory Model review of the sequential-processing guarantee

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,12 +32,23 @@ An actor is addressed only through an `ActorRef<T>` — a stable, thread-safe ha
 ## 3. Concurrency guarantees
 
 At most one invocation of `Actor.onMessage` (and `preStart`/`postStop`) runs at any instant for
-a given actor instance. This is currently achieved with the simplest possible mechanism: **each
-actor owns a single dedicated virtual thread for its entire lifetime**, and that thread is the
-only thread that ever calls into the actor's code. See `Dispatcher` and ADR-002.
+a given actor instance. This is achieved with the simplest possible mechanism: **each actor owns
+a single dedicated virtual thread for its entire lifetime**, and that thread is the only thread
+that ever calls into the actor's code. See `Dispatcher` and ADR-002.
 
-This is a full concurrency proof only informally, for M1. A rigorous Java Memory Model review is
-scheduled for M2 (TASK-207).
+**Java Memory Model review (TASK-207):** because all of an actor's own state is touched only by
+that one thread, visibility across messages is plain program order — no synchronization is
+needed for actor-owned fields. The one real cross-thread boundary is the mailbox: its lock gives
+the happens-before edge that makes state a sender established before calling `tell()` visible
+inside `onMessage`, and this same edge underlies the ordering guarantees in ADR-003 and the
+lifecycle semantics in ADR-004. Lifecycle flags (`terminated`, `stopRequested`,
+`shuttingDown`) are `AtomicBoolean`, and the actor registry is a `ConcurrentHashMap`; both give
+their own documented cross-thread guarantees. Safe publication of a newly spawned actor to its
+dispatcher thread relies on `final` fields plus the JMM's documented happens-before edge for
+`Executor.execute()`. The one real pitfall is caller-side: mutating a message object *after*
+calling `tell()` is unguarded shared mutable state, same as anywhere else in Java — treat a
+message as handed off, not shared, once sent. Full derivation in
+`docs/decisions/ADR-005-jmm-review-sequential-processing.md`.
 
 ## 4. Mailbox
 

--- a/docs/decisions/ADR-005-jmm-review-sequential-processing.md
+++ b/docs/decisions/ADR-005-jmm-review-sequential-processing.md
@@ -1,0 +1,156 @@
+# ADR-005: Java Memory Model review of the sequential-processing guarantee
+
+* Status: Accepted
+* Written during: M2 (TASK-207)
+
+## Context
+
+TASK-106 (M1) guarantees at most one `Actor.onMessage` invocation in flight per actor at any
+instant, and `docs/architecture.md` §3 has, until now, stated only informally that this holds
+"because each actor owns a single dedicated virtual thread for its entire lifetime." That is true,
+but "informally" is not good enough for a guarantee the rest of the framework — and every
+application built on it — leans on to justify holding actor state in plain, unsynchronized fields.
+This ADR does the rigorous version: for every piece of shared mutable state the runtime touches,
+it identifies the exact Java Memory Model (JMM) rule that makes cross-thread visibility safe, or
+says plainly where none exists.
+
+Scope, per TASK-207 and the design document's Section 12 note ("Actor state, Mailboxes,
+Lifecycle, Scheduling"):
+
+1. Actor state itself.
+2. The mailbox as the boundary between sender threads and the actor's own thread.
+3. Lifecycle flags (`stopRequested`, `terminated`, `ActorSystem.shuttingDown`).
+4. The actor registry (`ActorSystem.actors`).
+5. Safe publication of an `ActorCell`'s own fields to the dispatcher thread that runs it.
+6. What the framework does *not* protect against.
+
+## Review
+
+### 1. Actor state — program order on a single thread, not cross-thread visibility
+
+`ActorSystem.spawn()` submits exactly one task, `cell::run`, to
+`Executors.newVirtualThreadPerTaskExecutor()`. That executor starts exactly one new virtual thread
+per submitted task and runs it to completion. `ActorCell.run()` calls `actor.preStart(context)`
+and then, in the same call stack on that same thread, loops calling `actor.onMessage(context,
+message)` until the actor stops, finishing with `actor.postStop(context)`.
+
+This means every read and write an `Actor` implementation makes to its own fields, across every
+message it ever processes, happens on one `java.lang.Thread` object, in program order (JLS
+17.4.5). No `volatile`, no lock, no atomic is needed for actor-owned state, because there is no
+second thread ever reading or writing it — this is not "very likely safe," it is categorically
+outside the set of situations the JMM's cross-thread visibility rules even apply to.
+
+**Virtual threads do not change this.** A virtual thread can be unmounted from one carrier
+(platform) thread and remounted onto a different one across a blocking operation (such as
+`Mailbox.take()`'s `Condition.await()`). This is invisible to the JMM: the memory model reasons
+about `java.lang.Thread` identity and program order on that logical thread, not about which OS
+thread happens to carry it at a given moment. The JDK's virtual-thread implementation is
+responsible for whatever low-level barriers are needed to make mounting/unmounting transparent;
+application and framework code never needs to reason about carrier threads at all. Worth stating
+explicitly here since it is a natural (and wrong) intuition to worry about.
+
+### 2. The mailbox — the one real cross-thread boundary
+
+Every other shared-state question in the runtime reduces to: is `Mailbox` correctly synchronized?
+It is the only structure regularly written by arbitrary sender threads and read by the actor's own
+dispatcher thread.
+
+`Mailbox.queue` (a plain, non-thread-safe `ArrayDeque`) and `Mailbox.closed` are **only ever
+touched while holding `Mailbox.lock`** — every access in `offer()`, `take()`, and `close()` is
+inside a `lock()/finally { unlock() }` block; there is no unguarded read or write of either field
+anywhere in the class. `java.util.concurrent.locks.Lock`'s documented memory consistency effects
+give the same guarantee as `synchronized`: actions in a thread prior to calling `unlock()`
+happen-before actions following a successful `lock()` by another thread. Concretely:
+
+* A sender's `offer()` call happens-before the dispatcher thread's `take()` call that dequeues that
+  same message — so any state the sender established before calling `tell()` (including
+  constructing the message object itself) is visible inside `onMessage` when that message is
+  processed. This is the mechanism ADR-003 already relies on for cross-sender causal ordering; this
+  review confirms *why* it is sound, not just that it is.
+* Symmetrically, `close()` happens-before any `offer()`/`take()` call that observes `closed ==
+  true`, which is what makes the discard/reject semantics in ADR-004 and §5/§6 of
+  `docs/architecture.md` reliably observable rather than racy.
+
+No gap was found here.
+
+### 3. Lifecycle flags
+
+`ActorCell.stopRequested`, `ActorCell.terminated`, and `ActorSystem.shuttingDown` are all
+`AtomicBoolean`, always accessed through its atomic methods (`compareAndSet`, `get`, `set`) —
+never as a plain field. `AtomicBoolean` (like all `java.util.concurrent.atomic` types) has
+`volatile`-equivalent read/write semantics: a `set(true)` happens-before any subsequent `get()`
+that observes `true`. Two consequences worth being explicit about, since applications and the
+testkit both depend on them:
+
+* `ActorCell.terminated.set(true)` runs at the very end of `finishTermination()` — **after**
+  `actor.postStop(context)` has returned. So once `ActorRef.isTerminated()` (and therefore
+  `Await.awaitTerminated` in `framework-testkit`) observes `true` from any thread, every side
+  effect the actor ever performed — every `onMessage`, and `postStop` itself — is guaranteed
+  visible to that observing thread. This is the property the testkit's failure assertions (TASK-110)
+  actually rely on, and it holds.
+* `ActorRefImpl.tell()`'s `terminated.get()` check and `ActorSystem.spawn()`'s
+  `shuttingDown.get()` check are correctness *optimizations* (fail fast without touching the
+  mailbox lock), not the sole enforcement mechanism — the mailbox's own `closed` flag, under its
+  own lock, is what actually guarantees a post-close `offer()` is rejected even in the race window
+  right around a stop request. No gap.
+
+### 4. The actor registry
+
+`ActorSystem.actors` is a `ConcurrentHashMap`. Its own documented guarantees cover every operation
+used here (`putIfAbsent`, `get`, `remove`, iteration in `shutdown()`) without any additional
+synchronization needed. No gap.
+
+### 5. Safe publication of `ActorCell` to its own dispatcher thread
+
+`ActorCell`'s `system`, `id`, `actor`, `mailbox`, `ref`, and `context` fields are all `final`,
+assigned in the constructor, which runs to completion (`new ActorCell<>(...)`) before
+`dispatcher.execute(cell::run)` is called — on the same thread, in program order. Two independent
+guarantees make the fully-constructed `ActorCell` (and the `Actor` instance inside it) safely
+visible to the new virtual thread that runs `cell::run`:
+
+* JLS 17.5's final-field safe-publication guarantee, and
+* `java.util.concurrent.Executor`'s documented memory consistency effects: "actions in a thread
+  prior to submitting a `Runnable` object to an `Executor` happen-before its execution begins,"
+  which applies to `Dispatcher.execute()` (a thin wrapper over
+  `ExecutorService.execute()`) exactly as it would to a raw call.
+
+No gap.
+
+### 6. What is explicitly *not* guaranteed
+
+* **Mutating a message after sending it.** The mailbox's happens-before edge covers state
+  established *before* `tell()` is called. If a sender keeps a reference to a mutable message
+  object and mutates it *after* calling `tell()`, there is no guarantee about which version (or
+  what partial state) the receiving actor observes — this is an ordinary shared-mutable-state bug,
+  not a framework gap, but it is exactly the kind of pitfall a JMM review exists to name rather
+  than leave implicit. Guidance: treat a message as handed off, not shared, the moment `tell()` is
+  called. Prefer immutable messages (records are a natural fit).
+* **`ActorSystem.close()` / `Dispatcher.close()` as a source of visibility.** `close()` blocks
+  until every actor's dispatcher thread has finished, but that "wait for completion" behavior is
+  not the same documented, citable happens-before edge as `AtomicBoolean` or a `Future.get()`
+  provides. Code that needs to observe a specific actor's final side effects should use
+  `ActorRef.isTerminated()` (§3, above), not "I called `close()` so everything must be visible."
+  In practice `close()` already goes through `ExecutorService.close()`'s own termination-tracking,
+  which is safe, but this ADR deliberately does not lean on that path as the *documented* public
+  guarantee.
+
+## Decision
+
+Adopt this review as the record of why TASK-106's guarantee holds. No code changes: the review
+found no visibility gap in the current implementation. `docs/architecture.md` §3 is updated to
+state the guarantee's basis directly (single dedicated thread + safe publication via the
+executor) instead of deferring to "informally, for M1." A new regression test,
+`SafePublicationTest` in `framework-core`, exercises the mailbox happens-before edge directly:
+a sender mutates a plain (non-volatile, non-atomic) field immediately before calling `tell()`,
+and the receiving actor's `onMessage` observes the update — repeated across many iterations and
+sender threads to keep the test meaningful as a guard against a future regression (e.g. someone
+swapping the mailbox's lock for something that doesn't provide the same happens-before edge).
+
+## Consequences
+
+* `docs/architecture.md` §3 now states the JMM basis for TASK-106 explicitly and links here.
+* The "don't mutate a message after sending it" guidance is added to `Actor`'s Javadoc, since it's
+  the one real caller-facing pitfall this review surfaced.
+* Any future change to `Mailbox`'s synchronization strategy, or to the one-thread-per-actor
+  dispatch strategy (TASK-303, M3), must re-derive these happens-before edges explicitly rather
+  than assume they still hold — this ADR is the checklist for that re-derivation.

--- a/framework-core/src/main/java/dev/actorframework/core/Actor.java
+++ b/framework-core/src/main/java/dev/actorframework/core/Actor.java
@@ -5,7 +5,15 @@ package dev.actorframework.core;
  *
  * <p>An actor never has two invocations of {@link #onMessage} running concurrently for the same
  * instance; the runtime guarantees at most one in-flight message per actor (TASK-106). Actor state
- * may therefore be held in plain (non-volatile, non-synchronized) fields.
+ * may therefore be held in plain (non-volatile, non-synchronized) fields — see the Java Memory
+ * Model review in {@code docs/decisions/ADR-005-jmm-review-sequential-processing.md} (TASK-207) for
+ * why this holds.
+ *
+ * <p><b>Do not mutate a message after sending it.</b> The mailbox guarantees that state a sender
+ * established <em>before</em> calling {@link ActorRef#tell} is visible inside {@link #onMessage}
+ * when that message is processed; it makes no guarantee about further mutation of a message object
+ * after {@code tell()} returns. Treat a message as handed off, not shared, once sent — prefer
+ * immutable messages (records are a natural fit).
  */
 public interface Actor<T> {
 

--- a/framework-core/src/test/java/dev/actorframework/core/SafePublicationTest.java
+++ b/framework-core/src/test/java/dev/actorframework/core/SafePublicationTest.java
@@ -1,0 +1,107 @@
+package dev.actorframework.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * TASK-207 (ADR-005): the mailbox's lock gives a happens-before edge from a sender's {@code tell()}
+ * to the receiving actor's {@code onMessage} — so a plain (non-volatile, non-atomic) field write a
+ * sender makes <em>before</em> calling {@code tell()} must be visible to the actor's dispatcher
+ * thread, even though it is always a different thread than the sender. These tests guard that edge
+ * directly, as a regression check against a future change to {@code Mailbox}'s synchronization
+ * strategy that might silently drop it.
+ *
+ * <p>Each message carries a freshly allocated {@link Holder}, mutated exactly once by the sender
+ * and never touched again — reusing a single shared cell across iterations would race against the
+ * actor's own (much slower) consumption and produce false failures unrelated to visibility, so this
+ * deliberately avoids that shape.
+ */
+class SafePublicationTest {
+
+  /** A plain mutable holder: the field under test is written via ordinary assignment. */
+  private static final class Holder {
+    int mutableValue;
+  }
+
+  private record Publish(Holder holder, int expected) {}
+
+  @Test
+  void stateWrittenBeforeTellIsVisibleInOnMessage() throws InterruptedException {
+    int iterations = 5_000;
+    try (ActorSystem system = ActorSystem.start("test")) {
+      AtomicInteger staleReads = new AtomicInteger(0);
+      CountDownLatch allProcessed = new CountDownLatch(iterations);
+
+      ActorRef<Publish> ref =
+          system.spawn(
+              () ->
+                  (context, message) -> {
+                    if (message.holder().mutableValue != message.expected()) {
+                      staleReads.incrementAndGet();
+                    }
+                    allProcessed.countDown();
+                  });
+
+      for (int i = 0; i < iterations; i++) {
+        Holder holder = new Holder();
+        holder.mutableValue = i;
+        ref.tell(new Publish(holder, i));
+      }
+
+      assertTrue(allProcessed.await(10, TimeUnit.SECONDS), "all messages should be processed");
+      assertEquals(
+          0,
+          staleReads.get(),
+          "actor observed a stale/reordered value of a plain field written before tell()");
+    }
+  }
+
+  @Test
+  void stateWrittenBeforeTellFromMultipleSenderThreadsIsVisible() throws InterruptedException {
+    int sendersCount = 8;
+    int perSender = 2_000;
+    try (ActorSystem system = ActorSystem.start("test")) {
+      AtomicInteger staleReads = new AtomicInteger(0);
+      CountDownLatch allProcessed = new CountDownLatch(sendersCount * perSender);
+
+      ActorRef<Publish> ref =
+          system.spawn(
+              () ->
+                  (context, message) -> {
+                    if (message.holder().mutableValue != message.expected()) {
+                      staleReads.incrementAndGet();
+                    }
+                    allProcessed.countDown();
+                  });
+
+      ExecutorService senders = Executors.newFixedThreadPool(sendersCount);
+      try {
+        for (int s = 0; s < sendersCount; s++) {
+          senders.execute(
+              () -> {
+                for (int i = 0; i < perSender; i++) {
+                  Holder holder = new Holder();
+                  holder.mutableValue = i;
+                  ref.tell(new Publish(holder, i));
+                }
+              });
+        }
+        assertTrue(allProcessed.await(10, TimeUnit.SECONDS), "all messages should be processed");
+      } finally {
+        senders.shutdown();
+      }
+
+      assertEquals(
+          0,
+          staleReads.get(),
+          "actor observed a stale/reordered value of a plain field written before tell()");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds ADR-005, a rigorous Java Memory Model review of TASK-106's "at most one in-flight message per actor" guarantee, closing TASK-207 (M2).
- Reviews every piece of shared mutable state the runtime touches: actor state (single-thread program order — visibility isn't a cross-thread question at all), the mailbox (the one real cross-thread boundary, protected by `Mailbox`'s lock), lifecycle flags (`AtomicBoolean`), the actor registry (`ConcurrentHashMap`), and safe publication of a newly spawned `ActorCell` to its dispatcher thread (`final` fields + `Executor`'s documented happens-before). No gap found; no production code changes.
- Explicitly names the one real caller-facing pitfall the review surfaced: mutating a message object *after* calling `tell()` is unguarded shared mutable state. Documented in `Actor`'s Javadoc and in the ADR.
- Updates `docs/architecture.md` §3 to state the guarantee's basis directly instead of deferring to "informally, for M1."

## Test plan
- [x] New `SafePublicationTest` (`framework-core`) exercises the mailbox's happens-before edge directly: a sender writes a plain, non-volatile field on a freshly allocated per-message holder immediately before `tell()`, and the receiving actor's `onMessage` — always a different thread — must observe it. Single-sender (5,000 iterations) and 8-thread multi-sender (2,000 each) variants.
- [x] Deliberately avoided a shared-cell-reused-across-iterations design for this test, since the sender loop runs far ahead of the (slower) actor consuming messages — that shape would produce false failures unrelated to visibility, not a meaningful test.
- [x] `./gradlew clean build` passes (spotless formatting check + full test suite, including the two new tests run explicitly with `--rerun` to confirm they're not just cached).

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp)_