### PR TITLE
TASK-302: JMH messaging throughput and latency-distribution benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,6 +17,7 @@ Standard JMH command-line options can be passed through, e.g. to run one benchma
 ```
 ./gradlew :benchmarks:jmh -Pjmh.includes=DispatchRoundTripBenchmark
 ./gradlew :benchmarks:jmh -Pjmh.includes=ActorCountScalabilityBenchmark -Pjmh.benchmarkParameters=actorCount=100000
+./gradlew :benchmarks:jmh -Pjmh.includes=MessagingLatencyDistributionBenchmark
 ```
 
 ## TASK-301: dispatch strategy measurement
@@ -41,4 +42,25 @@ work.
 carrying a `CountDownLatch` in the message rather than a request-response call — see
 `LatchCountingActor`.
 
-TASK-302, TASK-307, and TASK-308 are not yet implemented; see the open issues for what remains.
+## TASK-302: messaging throughput and latency distribution
+
+The original design document's Section 12 asks specifically for Messages/sec and a p50/p95/p99/p999
+latency breakdown — a percentile distribution, not just an average. TASK-301's benchmarks give solid
+throughput numbers (`ActorCountScalabilityBenchmark`'s `actorCount=1` row is itself a "messages/sec
+against one actor under 16 senders" data point) but nothing yet reports the tail, which is exactly
+where mailbox contention (lock acquisition, block-on-full backpressure — TASK-103a/ADR-003) actually
+shows up and an average or throughput number alone hides.
+
+`MessagingLatencyDistributionBenchmark` closes that gap, against a single already-warm actor:
+
+* `throughputUnderLoad` — Messages/sec under 16 concurrent senders (`Mode.Throughput`).
+* `latencyUncontended` — full latency distribution with a single sender (`Mode.SampleTime`), as a
+  clean baseline.
+* `latencyUnderLoad` — full latency distribution under the same 16-sender load as the throughput
+  benchmark — the number that actually answers TASK-302's question.
+
+JMH's `SampleTime` mode buckets individual invocation timings into percentiles automatically
+(`p50.0`, `p90.0`, `p95.0`, `p99.0`, `p99.9`, `p99.99`, `p99.999`, `p100`) — "p999" in the original
+document is the industry-standard shorthand for the 99.9th percentile, i.e. JMH's `p99.9` row.
+
+TASK-307 and TASK-308 are not yet implemented; see the open issues for what remains.

--- a/benchmarks/src/jmh/java/dev/actorframework/benchmarks/MessagingLatencyDistributionBenchmark.java
+++ b/benchmarks/src/jmh/java/dev/actorframework/benchmarks/MessagingLatencyDistributionBenchmark.java
@@ -1,0 +1,93 @@
+package dev.actorframework.benchmarks;
+
+import dev.actorframework.core.ActorRef;
+import dev.actorframework.core.ActorSystem;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * TASK-302: messaging throughput and full latency-distribution measurement for a single actor.
+ *
+ * <p>TASK-301's {@code ActorCountScalabilityBenchmark} already reports a throughput number for one
+ * actor under 16 concurrent senders (its {@code actorCount=1} row), but throughput and simple
+ * average latency both hide the tail — exactly where mailbox contention (lock acquisition,
+ * block-on-full backpressure, TASK-103a/ADR-003) actually shows up. This class closes that gap:
+ * {@link #latencyUnderLoad} uses JMH's {@code SampleTime} mode, which buckets individual invocation
+ * timings into percentiles automatically. "p999" in the original design document is the
+ * industry-standard shorthand for the 99.9th percentile — JMH's {@code p99.9} bucket in the result
+ * table below; JMH reports {@code p50.0}, {@code p90.0}, {@code p95.0}, {@code p99.0}, {@code
+ * p99.9}, {@code p99.99}, {@code p99.999}, and {@code p100} by default, which covers
+ * p50/p95/p99/p999 directly.
+ *
+ * <p>{@link #latencyUncontended} is the same measurement with a single sender, as a clean baseline
+ * to compare the contended distribution against — contention should widen the tail without
+ * necessarily moving the median much, and that gap is itself useful data.
+ */
+@State(Scope.Benchmark)
+@Fork(2)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class MessagingLatencyDistributionBenchmark {
+
+  private static final int CONTENDED_SENDER_THREADS = 16;
+
+  private ActorSystem system;
+  private ActorRef<CountDownLatch> actor;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    system = ActorSystem.start("messaging-latency-distribution-benchmark");
+    actor = system.spawn(LatchCountingActor::new);
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    system.close();
+  }
+
+  /** Messages/sec against a single actor under realistic concurrent sender load. */
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  @Threads(CONTENDED_SENDER_THREADS)
+  public void throughputUnderLoad() throws InterruptedException {
+    roundTrip();
+  }
+
+  /** Full latency distribution (p50/p95/p99/p999) with a single, uncontended sender. */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Threads(1)
+  public void latencyUncontended() throws InterruptedException {
+    roundTrip();
+  }
+
+  /** Full latency distribution (p50/p95/p99/p999) under the same contended load as throughput. */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Threads(CONTENDED_SENDER_THREADS)
+  public void latencyUnderLoad() throws InterruptedException {
+    roundTrip();
+  }
+
+  private void roundTrip() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+    actor.tell(latch);
+    latch.await();
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `MessagingLatencyDistributionBenchmark`, closing TASK-302 (M3).
- The original design document's Section 12 asks specifically for Messages/sec plus a p50/p95/p99/p999 latency breakdown — a percentile distribution, not just an average. TASK-301 already gives solid throughput numbers (`ActorCountScalabilityBenchmark`'s `actorCount=1` row is itself a "messages/sec against one actor under 16 senders" data point), but nothing yet reports the tail latency distribution — exactly where mailbox contention (lock acquisition, block-on-full backpressure — TASK-103a/ADR-003) actually shows up and an average or throughput number alone hides.
- Three benchmarks against a single already-warm actor:
  - `throughputUnderLoad` — Messages/sec under 16 concurrent senders (`Mode.Throughput`).
  - `latencyUncontended` — full latency distribution (`Mode.SampleTime`) with a single sender, as a clean baseline.
  - `latencyUnderLoad` — full latency distribution under the same 16-sender load as `throughputUnderLoad` — the number that actually answers TASK-302's question.
- JMH's `SampleTime` mode buckets individual invocation timings into percentiles automatically (`p50.0`, `p90.0`, `p95.0`, `p99.0`, `p99.9`, `p99.99`, `p99.999`, `p100`); "p999" in the original document is the industry-standard shorthand for the 99.9th percentile, i.e. JMH's `p99.9` row.
- Updates `benchmarks/README.md` with the TASK-302 section and how to run just this class.

## Test plan
- [x] `./gradlew clean build` passes (spotless, compile, full unit test suite; JMH is not part of `build`/`check`, same as TASK-301).
- [x] Ran the full JMH suite locally (`./gradlew :benchmarks:jmh`), ~2 minutes:
  - `throughputUnderLoad` ≈ 102,770 ± 3,211 ops/s — cross-validates against TASK-301's independently measured `ActorCountScalabilityBenchmark.roundTrip(actorCount=1)` ≈ 104,057 ops/s from the same run.
  - `latencyUncontended` p50/p95/p99/p99.9 ≈ 21 / 38 / 67 / 196 µs.
  - `latencyUnderLoad` p50/p95/p99/p99.9 ≈ 151 / 194 / 244 / 526 µs — the expected widening tail under contention versus the uncontended baseline.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp)_