### PR TITLE
TASK-303: Evaluate the shared-executor dispatch alternative against benchmark data

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-JMH benchmark suite for the actor runtime (M3): TASK-301, TASK-302, TASK-307, TASK-308.
+JMH benchmark suite for the actor runtime (M3): TASK-301, TASK-302, TASK-303, TASK-307, TASK-308.
 
 Benchmark sources live in `src/jmh/java`, using the
 [`me.champeau.jmh`](https://github.com/melix/jmh-gradle-plugin) Gradle plugin. They are not part
@@ -18,6 +18,7 @@ Standard JMH command-line options can be passed through, e.g. to run one benchma
 ./gradlew :benchmarks:jmh -Pjmh.includes=DispatchRoundTripBenchmark
 ./gradlew :benchmarks:jmh -Pjmh.includes=ActorCountScalabilityBenchmark -Pjmh.benchmarkParameters=actorCount=100000
 ./gradlew :benchmarks:jmh -Pjmh.includes=MessagingLatencyDistributionBenchmark
+./gradlew :benchmarks:jmh -Pjmh.includes=SharedPoolDispatchBenchmark
 ```
 
 ## TASK-301: dispatch strategy measurement
@@ -62,5 +63,19 @@ shows up and an average or throughput number alone hides.
 JMH's `SampleTime` mode buckets individual invocation timings into percentiles automatically
 (`p50.0`, `p90.0`, `p95.0`, `p99.0`, `p99.9`, `p99.99`, `p99.999`, `p100`) — "p999" in the original
 document is the industry-standard shorthand for the 99.9th percentile, i.e. JMH's `p99.9` row.
+
+## TASK-303: dispatch strategy evaluation
+
+ADR-002 deferred one specific alternative to real measurement: a shared executor (a fixed pool of
+threads processing a queue of "actor has work" events) instead of one dedicated virtual thread per
+actor. `SharedPoolActorCell` (in `src/main/java`, so both `src/test/java` and `src/jmh/java` can
+see it) is a minimal but correct prototype of that pattern — `SharedPoolActorCellTest` proves it
+gives the same delivery and sequential-processing guarantees `ActorCell` does before any benchmark
+number from it is trusted. `SharedPoolDispatchBenchmark` runs the exact same workload shape as
+TASK-301's `ActorCountScalabilityBenchmark` against it, so the two are directly comparable.
+
+Result: the shared executor loses decisively and consistently at every actor count tested — see
+ADR-006 for the full comparison and data. ADR-002's strategy is confirmed, not replaced; no changes
+to `framework-core`.
 
 TASK-307 and TASK-308 are not yet implemented; see the open issues for what remains.

--- a/benchmarks/src/jmh/java/dev/actorframework/benchmarks/SharedPoolDispatchBenchmark.java
+++ b/benchmarks/src/jmh/java/dev/actorframework/benchmarks/SharedPoolDispatchBenchmark.java
@@ -1,0 +1,79 @@
+package dev.actorframework.benchmarks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * TASK-303: the same round-trip throughput measurement as TASK-301's {@code
+ * ActorCountScalabilityBenchmark} — same actor counts, same 16 concurrent sender threads, same
+ * round-robin send pattern — but against {@link SharedPoolActorCell} (ADR-002's "shared executor"
+ * alternative) instead of the real {@code ActorSystem}'s one-virtual-thread-per-actor dispatch
+ * strategy. Matching the workload shape exactly is what makes the two directly comparable rather
+ * than measuring two different things.
+ *
+ * <p>The shared pool is a fixed-size platform-thread pool sized to the available processors — the
+ * classical shape of this alternative (a small, bounded number of worker threads shared across a
+ * potentially much larger number of actors), as opposed to a thread per actor.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 3, time = 1)
+public class SharedPoolDispatchBenchmark {
+
+  private static final int SENDER_THREADS = 16;
+
+  @Param({"1", "10", "100", "1000", "10000"})
+  public int actorCount;
+
+  private ExecutorService pool;
+  private List<SharedPoolActorCell<CountDownLatch>> actors;
+  private AtomicInteger nextActor;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    pool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+    actors = new ArrayList<>(actorCount);
+    for (int i = 0; i < actorCount; i++) {
+      actors.add(new SharedPoolActorCell<>(pool, CountDownLatch::countDown));
+    }
+    nextActor = new AtomicInteger();
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    pool.shutdown();
+  }
+
+  /** One round trip against an actor picked round-robin from the {@code actorCount} live actors. */
+  @Benchmark
+  @Threads(SENDER_THREADS)
+  public void roundTrip() throws InterruptedException {
+    SharedPoolActorCell<CountDownLatch> actor =
+        actors.get(Math.floorMod(nextActor.getAndIncrement(), actorCount));
+    CountDownLatch latch = new CountDownLatch(1);
+    actor.tell(latch);
+    latch.await();
+  }
+}

--- a/benchmarks/src/main/java/dev/actorframework/benchmarks/SharedPoolActorCell.java
+++ b/benchmarks/src/main/java/dev/actorframework/benchmarks/SharedPoolActorCell.java
@@ -1,0 +1,65 @@
+package dev.actorframework.benchmarks;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+/**
+ * TASK-303: a minimal prototype of ADR-002's "shared executor" alternative — a fixed pool of
+ * threads shared across many actors, each actor scheduled onto the pool only when it has work and
+ * isn't already scheduled, draining a bounded batch of messages before yielding the thread back to
+ * the pool. This is the classical event-driven dispatcher pattern (the shape of, e.g., Akka's
+ * default dispatcher), contrasted against ADR-002's one-dedicated-thread-per-actor strategy that
+ * blocks on {@code mailbox.take()} for the actor's entire lifetime.
+ *
+ * <p>Deliberately not wired into {@code framework-core} — this exists purely to produce comparable
+ * benchmark data for TASK-303's ADR-gated decision (see {@code AGENTS.md}: the dispatch strategy is
+ * not changed ad hoc). It reimplements just enough (a FIFO mailbox and the sequential-processing
+ * guarantee) to be a fair comparison point, not a candidate drop-in replacement for {@code
+ * ActorCell}.
+ *
+ * <p>Sequential processing is guaranteed the same way real event-driven dispatchers guarantee it:
+ * {@code scheduled} is a compare-and-set gate, so at most one {@link #drain} task per actor is ever
+ * queued or running on the shared pool at a time; a message that arrives in the narrow window
+ * between a drain finishing its batch and clearing the flag is caught by the
+ * re-check-and-reschedule at the end of {@link #drain}.
+ */
+final class SharedPoolActorCell<T> {
+
+  private static final int MAX_MESSAGES_PER_DRAIN = 16;
+
+  private final ConcurrentLinkedQueue<T> mailbox = new ConcurrentLinkedQueue<>();
+  private final AtomicBoolean scheduled = new AtomicBoolean(false);
+  private final ExecutorService pool;
+  private final Consumer<T> onMessage;
+
+  SharedPoolActorCell(ExecutorService pool, Consumer<T> onMessage) {
+    this.pool = pool;
+    this.onMessage = onMessage;
+  }
+
+  void tell(T message) {
+    mailbox.add(message);
+    scheduleIfNeeded();
+  }
+
+  private void scheduleIfNeeded() {
+    if (scheduled.compareAndSet(false, true)) {
+      pool.execute(this::drain);
+    }
+  }
+
+  private void drain() {
+    int processed = 0;
+    T message;
+    while (processed < MAX_MESSAGES_PER_DRAIN && (message = mailbox.poll()) != null) {
+      onMessage.accept(message);
+      processed++;
+    }
+    scheduled.set(false);
+    if (!mailbox.isEmpty()) {
+      scheduleIfNeeded();
+    }
+  }
+}

--- a/benchmarks/src/test/java/dev/actorframework/benchmarks/SharedPoolActorCellTest.java
+++ b/benchmarks/src/test/java/dev/actorframework/benchmarks/SharedPoolActorCellTest.java
@@ -1,0 +1,90 @@
+package dev.actorframework.benchmarks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Before trusting benchmark numbers from {@link SharedPoolActorCell}, this proves it actually gives
+ * the same two guarantees {@code ActorCell} does (TASK-106): every message delivered exactly once,
+ * and never two messages processed concurrently — despite many actors sharing a small, fixed thread
+ * pool instead of each owning a dedicated thread.
+ */
+class SharedPoolActorCellTest {
+
+  @Test
+  void deliversEveryMessageExactlyOnceUnderConcurrentSenders() throws InterruptedException {
+    int messageCount = 20_000;
+    ExecutorService pool = Executors.newFixedThreadPool(4);
+    try {
+      List<Integer> received = new CopyOnWriteArrayList<>();
+      CountDownLatch allProcessed = new CountDownLatch(messageCount);
+      SharedPoolActorCell<Integer> actor =
+          new SharedPoolActorCell<>(
+              pool,
+              message -> {
+                received.add(message);
+                allProcessed.countDown();
+              });
+
+      ExecutorService senders = Executors.newFixedThreadPool(8);
+      try {
+        for (int i = 0; i < messageCount; i++) {
+          int message = i;
+          senders.execute(() -> actor.tell(message));
+        }
+        assertTrue(allProcessed.await(10, TimeUnit.SECONDS), "all messages should be processed");
+      } finally {
+        senders.shutdown();
+      }
+
+      assertEquals(messageCount, received.size(), "no message should be lost or duplicated");
+    } finally {
+      pool.shutdown();
+    }
+  }
+
+  @Test
+  void neverProcessesTwoMessagesConcurrentlyAcrossSharedPoolThreads() throws InterruptedException {
+    int messageCount = 20_000;
+    ExecutorService pool = Executors.newFixedThreadPool(4);
+    try {
+      AtomicInteger inFlight = new AtomicInteger(0);
+      AtomicInteger concurrencyViolations = new AtomicInteger(0);
+      CountDownLatch allProcessed = new CountDownLatch(messageCount);
+      SharedPoolActorCell<Integer> actor =
+          new SharedPoolActorCell<>(
+              pool,
+              message -> {
+                if (inFlight.incrementAndGet() > 1) {
+                  concurrencyViolations.incrementAndGet();
+                }
+                Thread.onSpinWait();
+                inFlight.decrementAndGet();
+                allProcessed.countDown();
+              });
+
+      ExecutorService senders = Executors.newFixedThreadPool(8);
+      try {
+        for (int i = 0; i < messageCount; i++) {
+          senders.execute(() -> actor.tell(1));
+        }
+        assertTrue(allProcessed.await(10, TimeUnit.SECONDS), "all messages should be processed");
+      } finally {
+        senders.shutdown();
+      }
+
+      assertEquals(0, concurrencyViolations.get());
+    } finally {
+      pool.shutdown();
+    }
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,11 @@ a given actor instance. This is achieved with the simplest possible mechanism: *
 a single dedicated virtual thread for its entire lifetime**, and that thread is the only thread
 that ever calls into the actor's code. See `Dispatcher` and ADR-002.
 
+**Dispatch strategy confirmed with data (TASK-303):** the shared-executor alternative ADR-002
+deferred to measurement was built and benchmarked against the same workload as TASK-301/302's
+data. It loses decisively at every actor count tested — a fixed thread pool plateaus at the core
+count, while one-thread-per-actor keeps scaling well past it. See ADR-006 for the full comparison.
+
 **Java Memory Model review (TASK-207):** because all of an actor's own state is touched only by
 that one thread, visibility across messages is plain program order — no synchronization is
 needed for actor-owned fields. The one real cross-thread boundary is the mailbox: its lock gives

--- a/docs/decisions/ADR-002-virtual-threads-dispatch.md
+++ b/docs/decisions/ADR-002-virtual-threads-dispatch.md
@@ -1,6 +1,6 @@
 # ADR-002: Virtual threads as the initial execution model
 
-* Status: Accepted (provisional dispatch strategy — see "Revisit" below)
+* Status: Accepted — confirmed with benchmark data at TASK-303 (see ADR-006)
 * Written during: M0/M1
 
 ## Context
@@ -41,6 +41,12 @@ This is chosen because:
 
 TASK-303 (M3) evaluates all of these against real measurements and may replace this strategy.
 Until then, this ADR records *why* the current strategy was chosen, not that it is final.
+
+**Resolved at TASK-303 (ADR-006):** the shared-executor alternative was built and benchmarked
+against the exact same workload as TASK-301's data. It loses decisively and consistently across
+every actor count tested — a fixed thread pool plateaus at the core count, while one-thread-per-
+actor keeps scaling well past it. The strategy below is confirmed, not just provisional; see
+ADR-006 for the full comparison and its caveats.
 
 ## Consequences
 

--- a/docs/decisions/ADR-006-dispatch-strategy-shared-executor-evaluation.md
+++ b/docs/decisions/ADR-006-dispatch-strategy-shared-executor-evaluation.md
@@ -1,0 +1,106 @@
+# ADR-006: Dispatch strategy — evaluating the shared-executor alternative (TASK-303)
+
+* Status: Accepted
+* Written during: M3 (TASK-303)
+* Supersedes: nothing — confirms ADR-002's provisional strategy with data, as ADR-002 itself
+  called for
+
+## Context
+
+ADR-002 chose one dedicated virtual thread per actor for M1, explicitly deferring two
+alternatives to real measurement rather than guessing: a **shared executor** (a fixed pool of
+threads processing a queue of "actor has work" events) and **work-stealing/hybrid schedulers**
+(deferred entirely, not evaluated until there is data motivating them). Per `AGENTS.md`, the
+dispatch strategy is an ADR-gated decision — it does not change without one.
+
+TASK-301/302 already produced throughput and latency data for the current strategy. TASK-303's
+job is to build the same measurement for the shared-executor alternative and compare.
+
+## What was built and measured
+
+`SharedPoolActorCell` (in the `benchmarks` module, not wired into `framework-core`): a minimal
+but correct prototype of the shared-executor pattern ADR-002 described — a fixed pool of platform
+threads (sized to `Runtime.availableProcessors()`, 4 on the machine these numbers were measured
+on), with each actor scheduled onto the pool only when it has work and isn't already scheduled
+(a compare-and-set gate), draining up to 16 messages per turn before yielding the thread back to
+the pool. This is the same pattern real event-driven dispatchers use (e.g. Akka's default
+dispatcher) and is deliberately *not* a hypothetical strawman: `SharedPoolActorCellTest` proves it
+gives the same two guarantees `ActorCell` does — every message delivered exactly once, and never
+two messages processed concurrently for the same actor — under real concurrent load, before any
+benchmark number from it is trusted.
+
+`SharedPoolDispatchBenchmark` runs the *exact* workload shape as TASK-301's
+`ActorCountScalabilityBenchmark` — same actor counts (1/10/100/1,000/10,000), same 16 concurrent
+sender threads, same round-robin send pattern — against `SharedPoolActorCell` instead of the real
+`ActorSystem`. Matching the workload exactly is what makes the two numbers comparable rather than
+measuring two different things.
+
+## Results
+
+Both suites measured back-to-back on the same 4-core machine:
+
+| Actors | One-thread-per-actor (ADR-002, TASK-301) | Shared 4-thread pool (this ADR) | Per-actor-thread advantage |
+|---|---|---|---|
+| 1 | ≈104,057 ops/s | ≈66,131 ops/s | ~1.6× |
+| 10 | ≈196,306–207,049 ops/s | ≈168,292 ops/s | ~1.2× |
+| 100 | ≈314,304–347,691 ops/s | ≈171,889 ops/s | ~1.9× |
+| 1,000 | ≈404,853–416,656 ops/s | ≈176,299 ops/s | ~2.3× |
+| 10,000 | ≈319,390–360,420 ops/s | ≈172,070 ops/s | ~2× |
+
+The confidence intervals on both suites are wide (this is a shared, virtualized sandbox, not a
+dedicated benchmark machine — see the same caveat in TASK-301/302's own data), but the shape is
+consistent and repeats across the full actor-count sweep, which is what a single noisy number
+would not give confidence in:
+
+* The **shared pool's throughput plateaus almost immediately**, around ~170K ops/s from 10 actors
+  onward, and never grows further as actor count increases to 1,000 or 10,000. This is exactly
+  what the design predicts: the pool itself — 4 platform threads — is the hard ceiling on
+  concurrent work, regardless of how many actors exist above that.
+* The **one-thread-per-actor strategy keeps scaling** well past the 4-core ceiling (up to
+  ~400K ops/s around 1,000 actors) because many parked virtual threads let the JVM interleave
+  work across blocking points far more cheaply than a fixed pool of platform threads can, and
+  there is no shared bottleneck resource analogous to the pool.
+* The one-thread-per-actor strategy wins at **every** actor count tested, including the
+  single-actor case, where there is no pool-contention story at all — the shared-pool's
+  scheduling overhead (the compare-and-set gate, the executor hand-off) is itself more expensive
+  than a virtual thread already parked in `mailbox.take()` waking up.
+
+## Decision
+
+**Keep ADR-002's one-dedicated-virtual-thread-per-actor strategy.** The shared-executor
+alternative it deferred to real measurement is now measured, and loses decisively and
+consistently, not marginally or only in an edge case. Adopting it would trade away real,
+measured throughput for "better resource control" that this runtime does not currently need —
+exactly the kind of premature optimization Section 12 of the design document warns against
+("no performance optimization is accepted without a benchmark," which cuts both ways: a
+*regression* also needs a benchmark before it's accepted).
+
+Work-stealing and hybrid schedulers remain out of scope, unchanged from ADR-002: they were
+deferred pending data motivating them, and a shared *fixed* pool — the simpler alternative in the
+same family — just lost decisively. There is no motivating data to build the more complex
+variants right now.
+
+## What this does not cover
+
+* Only a fixed **platform-thread** pool was measured, per ADR-002's literal description of the
+  alternative. A shared pool of *virtual* threads used the same way (scheduled per-turn rather
+  than parked for an actor's whole lifetime) was not benchmarked and might behave differently —
+  if a future concrete need motivates revisiting dispatch strategy, that variant is the first
+  place to look, not a reason to reopen this decision speculatively now.
+* `SharedPoolActorCell`'s batch size (16 messages per turn) was not tuned or swept. A different
+  batch size could shift the shared pool's numbers somewhat, but would not remove its structural
+  ceiling (a fixed number of threads bounds concurrent work no matter how large the batch is) —
+  the qualitative conclusion (it plateaus; per-actor threads don't) would not change.
+* This is one hardware profile (4 cores, shared/virtualized). The *shape* of the result — a fixed
+  pool plateaus at the core count, per-actor virtual threads keep scaling — is expected to
+  generalize, but the exact crossover numbers would differ on different hardware.
+
+## Consequences
+
+* No change to `framework-core`: `Dispatcher` and `ActorCell` are unchanged.
+* `SharedPoolActorCell` and `SharedPoolDispatchBenchmark` remain in the `benchmarks` module as the
+  recorded comparison point — if dispatch strategy is ever revisited (e.g. at much higher actor
+  counts than tested here, or on hardware with a very different core count), this is the harness
+  to extend rather than rebuild.
+* ADR-002's "Alternatives considered" section is now resolved with data for the shared-executor
+  option; TASK-303 is closed.


### PR DESCRIPTION
## Summary
- Closes TASK-303 (M3): evaluates ADR-002's deferred "shared executor" dispatch alternative against real benchmark data, per AGENTS.md's ADR-gated rule for dispatch-strategy changes — built and measured, not swapped in ad hoc.
- Adds `SharedPoolActorCell` (`benchmarks/src/main/java`, not wired into `framework-core`): a minimal but correct prototype of the shared-executor pattern ADR-002 described — a fixed platform-thread pool sized to available processors, with each actor scheduled onto the pool only when it has work and isn't already scheduled (a compare-and-set gate), draining a bounded batch (16 messages) per turn.
- Adds `SharedPoolActorCellTest`: proves the prototype gives the same two guarantees `ActorCell` does (every message delivered exactly once; never two messages processed concurrently for the same actor) under real concurrent load, *before* trusting any benchmark number from it.
- Adds `SharedPoolDispatchBenchmark`: runs the **exact same workload shape** as TASK-301's `ActorCountScalabilityBenchmark` (same actor counts 1/10/100/1,000/10,000, same 16 concurrent sender threads, same round-robin send pattern) against `SharedPoolActorCell` instead of the real `ActorSystem` — so the two numbers are directly comparable.
- Adds **ADR-006** recording the full comparison and decision. Updates ADR-002 and `docs/architecture.md` §3 to point at the resolution.

## Result

Measured back-to-back on the same 4-core machine:

| Actors | One-thread-per-actor (ADR-002) | Shared 4-thread pool |
|---|---|---|
| 1 | ≈104,057 ops/s | ≈66,131 ops/s |
| 10 | ≈196,306–207,049 ops/s | ≈168,292 ops/s |
| 100 | ≈314,304–347,691 ops/s | ≈171,889 ops/s |
| 1,000 | ≈404,853–416,656 ops/s | ≈176,299 ops/s |
| 10,000 | ≈319,390–360,420 ops/s | ≈172,070 ops/s |

The shared pool's throughput plateaus almost immediately around the core count and never grows further; the current strategy keeps scaling well past it, and wins at every actor count including the uncontended single-actor case. **Decision: keep ADR-002's one-thread-per-actor strategy — no changes to `framework-core`.** Work-stealing/hybrid schedulers remain out of scope (ADR-002 deferred them pending motivating data; the simpler shared-fixed-pool alternative just lost decisively, so there's none yet).

## Test plan
- [x] `SharedPoolActorCellTest` passes — correctness verified before trusting any benchmark number.
- [x] `./gradlew clean build` passes (spotless, compile including the new `benchmarks:test` and `benchmarks:compileJmhJava`, full unit test suite).
- [x] Ran the full JMH suite locally (`./gradlew :benchmarks:jmh`), ~2.5 minutes — `SharedPoolDispatchBenchmark` numbers above cross-checked against a fresh run of TASK-301's `ActorCountScalabilityBenchmark` in the same session.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp)_