### PR TITLE
TASK-307: Measure per-actor memory footprint

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -21,6 +21,13 @@ Standard JMH command-line options can be passed through, e.g. to run one benchma
 ./gradlew :benchmarks:jmh -Pjmh.includes=SharedPoolDispatchBenchmark
 ```
 
+TASK-307's memory-footprint measurement is not a JMH benchmark (see below for why) and runs via its
+own task instead:
+
+```
+./gradlew :benchmarks:memoryFootprint
+```
+
 ## TASK-301: dispatch strategy measurement
 
 ADR-002 (one dedicated virtual thread per actor) named two open questions it deferred to
@@ -78,4 +85,37 @@ Result: the shared executor loses decisively and consistently at every actor cou
 ADR-006 for the full comparison and data. ADR-002's strategy is confirmed, not replaced; no changes
 to `framework-core`.
 
-TASK-307 and TASK-308 are not yet implemented; see the open issues for what remains.
+## TASK-307: memory footprint per actor
+
+The design document's Section 12 also asks for memory per actor: an empty actor, an actor with a
+mailbox, and an actor under load. This is deliberately **not** a JMH benchmark: JMH's timing
+harness (and its bundled GCProfiler) measures allocation *rate* — bytes allocated per operation —
+which fits throughput/latency questions (TASK-301/302) but not "how much heap does N *live, idle*
+actors cost, standing around?" That is a retained-footprint snapshot, not a per-operation rate.
+
+`MemoryFootprintHarness` (a plain `main()`, not `@Benchmark`-annotated) measures it directly: force
+GC, sample `Runtime` heap usage, spawn or exercise N actors, sample again, divide the delta by N.
+Three scenarios:
+
+* **Empty actor** — freshly spawned, no message ever sent: the baseline cost of `ActorCell` plus a
+  never-touched `Mailbox` (whose backing `ArrayDeque` pre-sizes to 256 slots at construction,
+  regardless of whether it's ever used).
+* **Actor with mailbox after a burst, now idle** — every actor already has a mailbox from birth, so
+  the meaningful comparison isn't "with vs. without" but whether a mailbox that briefly held a
+  backlog leaves a permanently larger footprint once idle again. `ArrayDeque` never shrinks its
+  backing array back down after growing, so a burst of 300 messages (forced past the initial
+  256-slot array by briefly blocking the actor's own dispatcher thread) is expected to leave, and
+  did leave in a local run, a measurably larger idle footprint than an actor that was never
+  touched.
+* **Actor under sustained load** — memory sampled *while* many actors are being actively bombarded
+  with messages, not after things settle, and deliberately without a forced GC (which would itself
+  distort an active workload) — expect more sample-to-sample noise here than the other two
+  scenarios, including the occasional low or even near-zero delta if an unforced GC happens to run
+  during the sampling window; that's the tradeoff for not perturbing the live workload, not a bug.
+
+This is inherently approximate — `Runtime.gc()` is a request, not a guarantee, and heap usage
+includes JIT-compiled code and class-metadata growth unrelated to actor count — so all trials are
+printed, not just an average, to keep that noise visible rather than hidden behind one falsely
+precise number.
+
+TASK-308 is not yet implemented; see the open issues for what remains.

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -24,3 +24,15 @@ jmh {
     resultFormat.set("JSON")
     resultsFile.set(layout.buildDirectory.file("results/jmh/results.json"))
 }
+
+// TASK-307: a retained-heap-footprint measurement, deliberately not a JMH benchmark — JMH's
+// timing/allocation-rate model doesn't fit "how much memory does N idle actors cost." See
+// MemoryFootprintHarness for why and how.
+tasks.register<JavaExec>("memoryFootprint") {
+    group = "benchmark"
+    description = "TASK-307: standing memory footprint per actor (not JMH; see MemoryFootprintHarness)."
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("dev.actorframework.benchmarks.MemoryFootprintHarness")
+    // Spawning tens of thousands of actors (and their virtual threads) needs real heap room.
+    maxHeapSize = "1g"
+}

--- a/benchmarks/src/main/java/dev/actorframework/benchmarks/MemoryFootprintHarness.java
+++ b/benchmarks/src/main/java/dev/actorframework/benchmarks/MemoryFootprintHarness.java
@@ -1,0 +1,178 @@
+package dev.actorframework.benchmarks;
+
+import dev.actorframework.core.ActorRef;
+import dev.actorframework.core.ActorSystem;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * TASK-307: standing-memory-footprint measurement for actors — deliberately <em>not</em> a JMH
+ * benchmark.
+ *
+ * <p>JMH's timing-based harness (and its bundled GCProfiler) measures allocation <em>rate</em> —
+ * bytes allocated per operation — which is the right tool for the throughput/latency questions
+ * TASK-301/302 already answered. TASK-307 asks a different question: how much heap does N <em>live,
+ * idle</em> actors cost, just standing around? That is a retained-footprint snapshot, not a
+ * per-operation rate, so this uses a plain heap-delta measurement instead: force GC, sample {@code
+ * Runtime} heap usage, spawn or exercise N actors, sample again, divide the delta by N.
+ *
+ * <p>This is inherently approximate — {@code Runtime.gc()} is a request, not a guarantee, and JVM
+ * heap usage includes JIT-compiled code and class-metadata growth unrelated to actor count.
+ * Multiple trials are run and all of them reported, so the noise is visible rather than hidden
+ * behind one falsely precise number — the same honesty bar the JMH suite's own confidence intervals
+ * hold to.
+ *
+ * <p>Three scenarios, matching the design document's Section 12:
+ *
+ * <ul>
+ *   <li><b>Empty actor</b> — freshly spawned, no message ever sent: the baseline cost of {@code
+ *       ActorCell} plus a never-touched {@code Mailbox} (whose backing {@code ArrayDeque} pre-sizes
+ *       to 256 slots at construction, regardless of whether it is ever used).
+ *   <li><b>Actor with mailbox after a burst, now idle</b> — every actor already has a mailbox from
+ *       birth (there is no "actor without one" to compare against), so the meaningful comparison
+ *       is: does a mailbox that has briefly held a backlog leave a permanently larger footprint
+ *       once idle again? {@code ArrayDeque} never shrinks its backing array back down after
+ *       growing, so the answer is expected to be yes.
+ *   <li><b>Actor under sustained load</b> — memory sampled <em>while</em> many actors are being
+ *       actively bombarded with messages, not after things settle — the higher-water-mark profile
+ *       during real operation, deliberately without a forced GC (which would itself distort an
+ *       active workload).
+ * </ul>
+ *
+ * <p>Run via {@code ./gradlew :benchmarks:memoryFootprint}.
+ */
+public final class MemoryFootprintHarness {
+
+  private static final int ACTOR_COUNT = 10_000;
+  private static final int TRIALS = 3;
+  private static final int BURST_SIZE = 300; // > the mailbox's initial 256-slot backing array
+
+  public static void main(String[] args) throws InterruptedException {
+    System.out.println("TASK-307 memory footprint (best-effort, Runtime heap-delta sampling)");
+    System.out.println("Actors per trial: " + ACTOR_COUNT + ", trials: " + TRIALS);
+    System.out.println();
+
+    report("Empty actor (freshly spawned, no messages ever sent)", emptyActorScenario());
+    report("Actor whose mailbox grew from a burst, now idle again", burstThenIdleScenario());
+    report("Actor under sustained load (sampled live, no forced GC)", underLoadScenario());
+  }
+
+  private static long[] emptyActorScenario() throws InterruptedException {
+    long[] bytesPerActor = new long[TRIALS];
+    for (int trial = 0; trial < TRIALS; trial++) {
+      long before = usedMemoryAfterGc();
+      try (ActorSystem system = ActorSystem.start("memory-empty-actor")) {
+        List<ActorRef<Object>> actors = new ArrayList<>(ACTOR_COUNT);
+        for (int i = 0; i < ACTOR_COUNT; i++) {
+          ActorRef<Object> actor = system.spawn(() -> (context, message) -> {});
+          actors.add(actor);
+        }
+        long after = usedMemoryAfterGc();
+        bytesPerActor[trial] = (after - before) / actors.size();
+      }
+    }
+    return bytesPerActor;
+  }
+
+  private static long[] burstThenIdleScenario() throws InterruptedException {
+    long[] bytesPerActor = new long[TRIALS];
+    for (int trial = 0; trial < TRIALS; trial++) {
+      long before = usedMemoryAfterGc();
+      try (ActorSystem system = ActorSystem.start("memory-burst-then-idle")) {
+        List<CountDownLatch> drainedPerActor = new ArrayList<>(ACTOR_COUNT);
+        for (int i = 0; i < ACTOR_COUNT; i++) {
+          CountDownLatch drained = new CountDownLatch(BURST_SIZE);
+          drainedPerActor.add(drained);
+          ActorRef<Runnable> actor = system.spawn(() -> (context, message) -> message.run());
+          // Block this actor's own dispatcher thread mid-onMessage (not on mailbox.take()), so
+          // the burst below queues up behind it before draining, forcing the backing array to
+          // grow past its initial 256 slots.
+          actor.tell(() -> sleepQuietly(20));
+          for (int m = 0; m < BURST_SIZE; m++) {
+            actor.tell(drained::countDown);
+          }
+        }
+        for (CountDownLatch drained : drainedPerActor) {
+          drained.await(10, TimeUnit.SECONDS);
+        }
+        long after = usedMemoryAfterGc();
+        bytesPerActor[trial] = (after - before) / drainedPerActor.size();
+      }
+    }
+    return bytesPerActor;
+  }
+
+  private static long[] underLoadScenario() throws InterruptedException {
+    long[] bytesPerActor = new long[TRIALS];
+    int senderThreads = 8;
+    for (int trial = 0; trial < TRIALS; trial++) {
+      try (ActorSystem system = ActorSystem.start("memory-under-load")) {
+        List<ActorRef<Runnable>> actors = new ArrayList<>(ACTOR_COUNT);
+        for (int i = 0; i < ACTOR_COUNT; i++) {
+          ActorRef<Runnable> actor = system.spawn(() -> (context, message) -> message.run());
+          actors.add(actor);
+        }
+        long before = usedMemoryAfterGc();
+
+        AtomicBoolean keepSending = new AtomicBoolean(true);
+        ExecutorService senders = Executors.newFixedThreadPool(senderThreads);
+        for (int s = 0; s < senderThreads; s++) {
+          int senderIndex = s;
+          senders.execute(
+              () -> {
+                int next = senderIndex;
+                while (keepSending.get()) {
+                  actors.get(next % actors.size()).tell(() -> {});
+                  next += senderThreads;
+                }
+              });
+        }
+        sleepQuietly(500); // let load build up to a steady state before sampling
+        long duringLoad = currentUsedMemory(); // no forced GC: this is the live-workload profile
+
+        keepSending.set(false);
+        senders.shutdown();
+        senders.awaitTermination(5, TimeUnit.SECONDS);
+
+        bytesPerActor[trial] = (duringLoad - before) / actors.size();
+      }
+    }
+    return bytesPerActor;
+  }
+
+  private static long usedMemoryAfterGc() {
+    Runtime runtime = Runtime.getRuntime();
+    for (int i = 0; i < 3; i++) {
+      runtime.gc();
+      sleepQuietly(100);
+    }
+    return currentUsedMemory();
+  }
+
+  private static long currentUsedMemory() {
+    Runtime runtime = Runtime.getRuntime();
+    return runtime.totalMemory() - runtime.freeMemory();
+  }
+
+  private static void sleepQuietly(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static void report(String label, long[] bytesPerActor) {
+    double average = Arrays.stream(bytesPerActor).average().orElse(0);
+    System.out.printf(
+        "%-55s samples(bytes/actor)=%s avg=%.0f%n", label, Arrays.toString(bytesPerActor), average);
+  }
+
+  private MemoryFootprintHarness() {}
+}


### PR DESCRIPTION
## Summary
- Closes TASK-307 (M3): the design document's Section 12 asks for memory per actor — empty actor, actor with a mailbox, actor under load.
- Deliberately **not** a JMH benchmark: JMH's timing harness (and its bundled GCProfiler) measures allocation *rate*, which fits TASK-301/302's throughput/latency questions, not "how much heap does N live, idle actors cost, standing around?" — a retained-footprint snapshot, not a per-operation rate.
- Adds `MemoryFootprintHarness` (a plain `main()`, not `@Benchmark`-annotated): force GC, sample `Runtime` heap usage, spawn or exercise N actors, sample again, divide the delta by N. Three scenarios:
  - **Empty actor** — freshly spawned, no message ever sent.
  - **Actor with mailbox after a burst, now idle** — every actor already has a mailbox from birth, so the meaningful comparison is whether a mailbox that briefly held a backlog (forced past its initial 256-slot backing array by briefly blocking the actor's own dispatcher thread) leaves a permanently larger footprint once idle again — `ArrayDeque` never shrinks back down after growing.
  - **Actor under sustained load** — memory sampled live, without a forced GC that would itself distort the workload.
- Adds a `./gradlew :benchmarks:memoryFootprint` `JavaExec` task (not part of `build`/`check`, same reasoning as the JMH suite) and documents all of this in `benchmarks/README.md`.
- No ADR: this is a measurement task, not a decision, same as TASK-301/302 — TASK-306 (mailbox bounds revisit) is what turns this data, together with TASK-301/302's, into an actual decision.

## Test plan
- [x] `./gradlew clean build` passes (spotless, compile, full unit test suite).
- [x] Ran `./gradlew :benchmarks:memoryFootprint` locally (10,000 actors × 3 trials each scenario, ~9s): results matched the expected shape — burst-then-idle (avg ≈3,333 bytes/actor) came out higher than never-touched empty (avg ≈2,927 bytes/actor), consistent with `ArrayDeque`'s grow-and-never-shrink behavior; under-load showed more sample-to-sample noise as expected (no forced GC), including one low sample plausibly explained by an unforced GC landing inside the sampling window — documented as expected, not a bug.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp)_