### PR TITLE
TASK-306: confirm mailbox bounds/backpressure with benchmark data (ADR-007)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,11 +44,11 @@ Write an ADR in `docs/decisions/` (see existing ADRs for the format) before chan
 following — these are decisions later milestones are built on top of, and changing them silently
 risks invalidating work upstream or downstream of the change:
 
-* **Mailbox bounds / backpressure policy.** The current bounded, block-on-full default
-  (`Mailbox.DEFAULT_CAPACITY`) is explicitly provisional (TASK-103a,
-  `docs/decisions/mailbox-bounds-provisional.md`) and is meant to be revisited *once*, with
-  benchmark data, at TASK-306. Don't change it casually before then; don't leave it unexamined
-  after M3 benchmarks land either.
+* **Mailbox bounds / backpressure policy.** The bounded, block-on-full default
+  (`Mailbox.DEFAULT_CAPACITY`) was provisional (TASK-103a,
+  `docs/decisions/mailbox-bounds-provisional.md`) and has since been confirmed with benchmark data
+  at TASK-306 (`docs/decisions/ADR-007-mailbox-bounds-confirmed.md`). It is no longer provisional —
+  any future change to it needs a new ADR that engages with ADR-007's data, not a silent edit.
 * **What happens to queued messages when an actor stops** (currently: discarded, not delivered).
 * **The dispatch strategy** (currently: one dedicated virtual thread per actor for its whole
   lifetime). Alternatives are evaluated with benchmarks at TASK-303 (M3), not swapped in ad hoc.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,7 @@
 # Benchmarks
 
-JMH benchmark suite for the actor runtime (M3): TASK-301, TASK-302, TASK-303, TASK-307, TASK-308.
+JMH benchmark suite for the actor runtime (M3): TASK-301, TASK-302, TASK-303, TASK-306, TASK-307,
+TASK-308.
 
 Benchmark sources live in `src/jmh/java`, using the
 [`me.champeau.jmh`](https://github.com/melix/jmh-gradle-plugin) Gradle plugin. They are not part
@@ -19,6 +20,7 @@ Standard JMH command-line options can be passed through, e.g. to run one benchma
 ./gradlew :benchmarks:jmh -Pjmh.includes=ActorCountScalabilityBenchmark -Pjmh.benchmarkParameters=actorCount=100000
 ./gradlew :benchmarks:jmh -Pjmh.includes=MessagingLatencyDistributionBenchmark
 ./gradlew :benchmarks:jmh -Pjmh.includes=SharedPoolDispatchBenchmark
+./gradlew :benchmarks:jmh -Pjmh.includes=MailboxBackpressureBenchmark
 ```
 
 TASK-307's memory-footprint measurement is not a JMH benchmark (see below for why) and runs via its
@@ -117,5 +119,37 @@ This is inherently approximate — `Runtime.gc()` is a request, not a guarantee,
 includes JIT-compiled code and class-metadata growth unrelated to actor count — so all trials are
 printed, not just an average, to keep that noise visible rather than hidden behind one falsely
 precise number.
+
+## TASK-306: mailbox bounds/backpressure decision
+
+TASK-103a's bounded, block-on-full default (`Mailbox.DEFAULT_CAPACITY = 1024`) was explicitly
+provisional, deferred to real benchmark data at TASK-306. TASK-301/302's benchmarks don't supply
+that data by themselves: their busiest case (16 senders against one actor) never drives a mailbox
+anywhere near capacity 1024, so they show how the runtime behaves well below the limit, not what
+the limit itself costs or buys. TASK-306 closes that gap with two purpose-built measurements.
+
+`BoundedBlockingMailbox` (in `src/main/java`, so both `src/test/java` and `src/jmh/java` can see
+it) is a faithful copy of `framework-core`'s package-private `Mailbox`, parameterized by capacity —
+the real `Mailbox`'s capacity isn't public API, so this is the only way to compare capacities
+directly. `BoundedBlockingMailboxTest` proves it behaves identically (FIFO order, blocks while
+full, capacity enforced, unblocks on `close()`) before any benchmark number from it is trusted, the
+same discipline TASK-303's `SharedPoolActorCell` established.
+
+* `MailboxBackpressureBenchmark` — a consumer deliberately throttled to ~1 message/ms against 8
+  concurrent senders, so the mailbox is genuinely saturated throughout the run rather than only
+  occasionally full. Measures accepted throughput and `offer()` blocking latency at capacities 16,
+  128, 1024, and 8192. Result: both are invariant to capacity once saturated (~975-981 ops/s,
+  ~8140-8155 µs mean latency across all four) — exactly what queueing theory predicts once arrivals
+  exceed a bottlenecked consumer's fixed service rate.
+* A fourth `MemoryFootprintHarness` scenario (see below) fills `BoundedBlockingMailbox` instances to
+  exactly their capacity with a single shared sentinel message, isolating the backing array's cost
+  from per-message payload size. Result: retained memory scales roughly linearly with capacity once
+  actually saturated — 250 / 700 / 5,398 / 40,184 bytes per mailbox at capacities 16 / 128 / 1024 /
+  8192 — while the current default (1024) costs only ~5.4 KB even fully saturated, barely more than
+  TASK-307's idle-actor baseline.
+
+Decision: **confirm** the current default — bounded, block-on-full, capacity 1024. No change to
+`framework-core`. See `docs/decisions/ADR-007-mailbox-bounds-confirmed.md` for the full reasoning,
+including what this data does and doesn't cover.
 
 TASK-308 is not yet implemented; see the open issues for what remains.

--- a/benchmarks/src/jmh/java/dev/actorframework/benchmarks/MailboxBackpressureBenchmark.java
+++ b/benchmarks/src/jmh/java/dev/actorframework/benchmarks/MailboxBackpressureBenchmark.java
@@ -1,0 +1,107 @@
+package dev.actorframework.benchmarks;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * TASK-306: does the mailbox's specific capacity matter once a mailbox is actually driven to
+ * backpressure? None of TASK-301/302's benchmarks ever did — their busiest case (16 senders against
+ * one actor) never approaches the default capacity of 1,024, so they show how the runtime behaves
+ * well below the limit, not what the limit itself costs or buys. This benchmark closes that gap
+ * directly, against {@link BoundedBlockingMailbox} at several candidate capacities, with a consumer
+ * deliberately made the bottleneck so the mailbox is genuinely saturated throughout the measurement
+ * — not just occasionally full.
+ *
+ * <p>Queueing theory predicts: once arrivals exceed a fixed service rate, steady-state
+ * <em>acceptance</em> throughput is capped by the consumer's rate regardless of buffer size, and so
+ * is the average {@code offer()} blocking latency (roughly "how many senders are already ahead of
+ * me in the fair lock's queue, divided by the drain rate") — capacity mainly changes how much
+ * bursty demand can be absorbed before backpressure kicks in at all, and how much memory is
+ * retained while saturated (TASK-307 already showed the mailbox costs nothing extra for capacity
+ * that's never actually used). {@link #acceptanceThroughputUnderSaturation} and {@link
+ * #offerLatencyUnderSaturation} test that prediction directly rather than assuming it.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 3, time = 1)
+public class MailboxBackpressureBenchmark {
+
+  /** ~1ms of deliberately slow, fixed-rate processing — guarantees senders outpace the consumer. */
+  private static final long CONSUMER_PROCESSING_NANOS = 1_000_000;
+
+  private static final int SENDER_THREADS = 8;
+
+  @Param({"16", "128", "1024", "8192"})
+  public int capacity;
+
+  private BoundedBlockingMailbox<Object> mailbox;
+  private Thread consumer;
+  private volatile boolean stopConsumer;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    mailbox = new BoundedBlockingMailbox<>(capacity);
+    stopConsumer = false;
+    consumer =
+        new Thread(
+            () -> {
+              while (!stopConsumer) {
+                Object message = mailbox.take();
+                if (message == null) {
+                  return;
+                }
+                busySpin(CONSUMER_PROCESSING_NANOS);
+              }
+            });
+    consumer.setDaemon(true);
+    consumer.start();
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws InterruptedException {
+    stopConsumer = true;
+    mailbox.close();
+    consumer.join(TimeUnit.SECONDS.toMillis(5));
+  }
+
+  /** Messages/sec actually accepted once the mailbox is kept continuously saturated. */
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  @Threads(SENDER_THREADS)
+  public void acceptanceThroughputUnderSaturation() {
+    mailbox.offer(new Object());
+  }
+
+  /**
+   * How long offer() blocks per call under sustained saturation — the backpressure senders feel.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Threads(SENDER_THREADS)
+  public void offerLatencyUnderSaturation() {
+    mailbox.offer(new Object());
+  }
+
+  private static void busySpin(long nanos) {
+    long deadline = System.nanoTime() + nanos;
+    while (System.nanoTime() < deadline) {
+      Thread.onSpinWait();
+    }
+  }
+}

--- a/benchmarks/src/main/java/dev/actorframework/benchmarks/BoundedBlockingMailbox.java
+++ b/benchmarks/src/main/java/dev/actorframework/benchmarks/BoundedBlockingMailbox.java
@@ -1,0 +1,105 @@
+package dev.actorframework.benchmarks;
+
+import java.util.ArrayDeque;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * TASK-306: a faithful copy of {@code framework-core}'s package-private {@code Mailbox} — same
+ * fair-lock, {@code ArrayDeque}-backed, bounded/block-on-full design — so this benchmark module can
+ * compare different capacities directly. The real {@code Mailbox}'s capacity is not part of {@code
+ * framework-core}'s public API (only the single hardcoded default is; TASK-306 is about confirming
+ * or replacing that one default, not about adding per-actor configurability, which is a separate,
+ * undecided question), so there is no way to spawn an actor with a non-default mailbox capacity
+ * through the real framework. This class exists purely to produce comparable benchmark data for
+ * that decision — deliberately not wired into {@code framework-core}, the same shape as TASK-303's
+ * {@code SharedPoolActorCell}.
+ *
+ * <p>{@code BoundedBlockingMailboxTest} proves this copy behaves identically to the real {@code
+ * Mailbox} (FIFO order, blocks while full, capacity enforced) before any benchmark number from it
+ * is trusted.
+ */
+final class BoundedBlockingMailbox<T> {
+
+  private final ArrayDeque<T> queue;
+  private final int capacity;
+  private final ReentrantLock lock = new ReentrantLock(true);
+  private final Condition notFull = lock.newCondition();
+  private final Condition notEmpty = lock.newCondition();
+  private boolean closed = false;
+
+  BoundedBlockingMailbox(int capacity) {
+    if (capacity <= 0) {
+      throw new IllegalArgumentException("capacity must be positive: " + capacity);
+    }
+    this.capacity = capacity;
+    this.queue = new ArrayDeque<>(Math.min(capacity, 256));
+  }
+
+  boolean offer(T message) {
+    lock.lock();
+    try {
+      while (queue.size() >= capacity && !closed) {
+        awaitUninterruptibly(notFull);
+      }
+      if (closed) {
+        return false;
+      }
+      queue.addLast(message);
+      notEmpty.signal();
+      return true;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  T take() {
+    lock.lock();
+    try {
+      while (queue.isEmpty() && !closed) {
+        awaitUninterruptibly(notEmpty);
+      }
+      if (queue.isEmpty()) {
+        return null;
+      }
+      T message = queue.removeFirst();
+      notFull.signal();
+      return message;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  void close() {
+    lock.lock();
+    try {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      queue.clear();
+      notFull.signalAll();
+      notEmpty.signalAll();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private static void awaitUninterruptibly(Condition condition) {
+    boolean interrupted = false;
+    try {
+      while (true) {
+        try {
+          condition.await();
+          return;
+        } catch (InterruptedException e) {
+          interrupted = true;
+        }
+      }
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+}

--- a/benchmarks/src/main/java/dev/actorframework/benchmarks/MemoryFootprintHarness.java
+++ b/benchmarks/src/main/java/dev/actorframework/benchmarks/MemoryFootprintHarness.java
@@ -45,6 +45,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *       active workload).
  * </ul>
  *
+ * <p>A fourth scenario, added for TASK-306, isolates the specific question the mailbox-bounds
+ * decision needs answered: when a mailbox is actually filled to capacity, how much does the chosen
+ * capacity itself cost, independent of message payload size? It uses {@link BoundedBlockingMailbox}
+ * directly (not full actors) and a single shared sentinel object in every slot, so the measured
+ * delta is purely the backing array's cost at each capacity, not per-message allocation (which
+ * TASK-307's other scenarios already cover, and which varies by application payload anyway — not
+ * something the framework controls).
+ *
  * <p>Run via {@code ./gradlew :benchmarks:memoryFootprint}.
  */
 public final class MemoryFootprintHarness {
@@ -52,6 +60,10 @@ public final class MemoryFootprintHarness {
   private static final int ACTOR_COUNT = 10_000;
   private static final int TRIALS = 3;
   private static final int BURST_SIZE = 300; // > the mailbox's initial 256-slot backing array
+
+  private static final int MAILBOXES_FOR_SATURATION = 1_000;
+  private static final int[] SATURATION_CAPACITIES = {16, 128, 1024, 8192};
+  private static final Object SATURATION_SENTINEL = new Object();
 
   public static void main(String[] args) throws InterruptedException {
     System.out.println("TASK-307 memory footprint (best-effort, Runtime heap-delta sampling)");
@@ -61,6 +73,32 @@ public final class MemoryFootprintHarness {
     report("Empty actor (freshly spawned, no messages ever sent)", emptyActorScenario());
     report("Actor whose mailbox grew from a burst, now idle again", burstThenIdleScenario());
     report("Actor under sustained load (sampled live, no forced GC)", underLoadScenario());
+
+    System.out.println();
+    System.out.println(
+        "TASK-306: mailbox retained memory when actually filled to capacity (isolated mailbox,"
+            + " shared sentinel message, no actor)");
+    for (int capacity : SATURATION_CAPACITIES) {
+      report("  capacity=" + capacity, mailboxSaturationScenario(capacity));
+    }
+  }
+
+  private static long[] mailboxSaturationScenario(int capacity) {
+    long[] bytesPerMailbox = new long[TRIALS];
+    for (int trial = 0; trial < TRIALS; trial++) {
+      long before = usedMemoryAfterGc();
+      List<BoundedBlockingMailbox<Object>> mailboxes = new ArrayList<>(MAILBOXES_FOR_SATURATION);
+      for (int i = 0; i < MAILBOXES_FOR_SATURATION; i++) {
+        BoundedBlockingMailbox<Object> mailbox = new BoundedBlockingMailbox<>(capacity);
+        for (int m = 0; m < capacity; m++) {
+          mailbox.offer(SATURATION_SENTINEL);
+        }
+        mailboxes.add(mailbox);
+      }
+      long after = usedMemoryAfterGc();
+      bytesPerMailbox[trial] = (after - before) / mailboxes.size();
+    }
+    return bytesPerMailbox;
   }
 
   private static long[] emptyActorScenario() throws InterruptedException {

--- a/benchmarks/src/test/java/dev/actorframework/benchmarks/BoundedBlockingMailboxTest.java
+++ b/benchmarks/src/test/java/dev/actorframework/benchmarks/BoundedBlockingMailboxTest.java
@@ -1,0 +1,106 @@
+package dev.actorframework.benchmarks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+/**
+ * TASK-306: before trusting any benchmark number from {@link BoundedBlockingMailbox}, this proves
+ * it behaves the same as {@code framework-core}'s real {@code Mailbox} on the properties this
+ * benchmark's conclusions depend on: FIFO delivery, and blocking (not dropping or rejecting) while
+ * full until space frees or the mailbox closes.
+ */
+class BoundedBlockingMailboxTest {
+
+  @Test
+  void deliversMessagesInFifoOrder() {
+    BoundedBlockingMailbox<Integer> mailbox = new BoundedBlockingMailbox<>(16);
+    for (int i = 0; i < 10; i++) {
+      assertTrue(mailbox.offer(i));
+    }
+    for (int i = 0; i < 10; i++) {
+      assertEquals(i, mailbox.take());
+    }
+  }
+
+  @Test
+  void offerBlocksWhileFullAndUnblocksOnceSpaceFrees() throws InterruptedException {
+    BoundedBlockingMailbox<Integer> mailbox = new BoundedBlockingMailbox<>(1);
+    assertTrue(mailbox.offer(1));
+
+    AtomicBoolean secondOfferReturned = new AtomicBoolean(false);
+    CountDownLatch threadStarted = new CountDownLatch(1);
+    Thread sender =
+        new Thread(
+            () -> {
+              threadStarted.countDown();
+              mailbox.offer(2);
+              secondOfferReturned.set(true);
+            });
+    sender.start();
+    threadStarted.await();
+
+    Thread.sleep(100);
+    assertFalse(secondOfferReturned.get(), "offer() must block while the mailbox is full");
+
+    assertEquals(1, mailbox.take());
+    sender.join(Duration.ofSeconds(2).toMillis());
+    assertTrue(secondOfferReturned.get(), "offer() must unblock once space is available");
+    assertEquals(2, mailbox.take());
+  }
+
+  @Test
+  void closeUnblocksASenderWaitingOnAFullMailbox() throws InterruptedException {
+    BoundedBlockingMailbox<Integer> mailbox = new BoundedBlockingMailbox<>(1);
+    assertTrue(mailbox.offer(1));
+
+    AtomicBoolean offerReturned = new AtomicBoolean(false);
+    CountDownLatch threadStarted = new CountDownLatch(1);
+    Thread sender =
+        new Thread(
+            () -> {
+              threadStarted.countDown();
+              boolean enqueued = mailbox.offer(2);
+              assertFalse(enqueued, "a sender unblocked by close() must see its message dropped");
+              offerReturned.set(true);
+            });
+    sender.start();
+    threadStarted.await();
+    Thread.sleep(100);
+
+    mailbox.close();
+
+    sender.join(Duration.ofSeconds(2).toMillis());
+    assertTrue(offerReturned.get(), "close() must unblock a sender stuck on a full mailbox");
+  }
+
+  @Test
+  void neverExceedsItsConfiguredCapacity() throws InterruptedException {
+    int capacity = 8;
+    BoundedBlockingMailbox<Integer> mailbox = new BoundedBlockingMailbox<>(capacity);
+    for (int i = 0; i < capacity; i++) {
+      assertTrue(mailbox.offer(i));
+    }
+
+    AtomicBoolean overflowOfferReturned = new AtomicBoolean(false);
+    Thread sender =
+        new Thread(
+            () -> {
+              mailbox.offer(capacity);
+              overflowOfferReturned.set(true);
+            });
+    sender.start();
+
+    Thread.sleep(100);
+    assertFalse(overflowOfferReturned.get(), "offer() must block once capacity is reached");
+
+    mailbox.take();
+    sender.join(Duration.ofSeconds(2).toMillis());
+    assertTrue(overflowOfferReturned.get());
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,10 +59,14 @@ message as handed off, not shared, once sent. Full derivation in
 
 Each actor has its own `Mailbox<T>`, a FIFO queue.
 
-**Provisional bounds decision (TASK-103a):** the mailbox is bounded with a generous default
-capacity (1024) and blocks the sending thread when full ("block-on-full"). This is explicitly
-provisional — chosen only so early benchmarks are comparable — and is revisited with real
-measurement data at TASK-306 (M3). See `docs/decisions/mailbox-bounds-provisional.md`.
+**Bounds confirmed with benchmark data (TASK-306):** the mailbox is bounded with a default capacity
+of 1024 and blocks the sending thread when full ("block-on-full"). TASK-103a picked this only so
+early benchmarks would be comparable; TASK-306 built a dedicated benchmark to drive the mailbox to
+real backpressure (something TASK-301/302's realistic workloads never did) and confirmed both the
+policy and the specific capacity: throughput and blocking latency are invariant to capacity once
+saturated, and the current default costs only ~5.4 KB per actor even fully saturated. See
+`docs/decisions/ADR-007-mailbox-bounds-confirmed.md` (supersedes
+`docs/decisions/mailbox-bounds-provisional.md`).
 
 **Rejected message (TASK-203):** a rejected message is one offered to a mailbox that will never
 process it. Exactly three mechanisms produce a rejected message: `offer()` called after the

--- a/docs/decisions/ADR-007-mailbox-bounds-confirmed.md
+++ b/docs/decisions/ADR-007-mailbox-bounds-confirmed.md
@@ -1,0 +1,126 @@
+# ADR-007: Mailbox bounds and backpressure — confirmed with benchmark data (TASK-306)
+
+* Status: Accepted
+* Written during: M3 (TASK-306)
+* Finalizes: TASK-103a's provisional default (`docs/decisions/mailbox-bounds-provisional.md`)
+* Builds on: ADR-004 (overflow/poison/rejection semantics — the qualitative policy, already
+  formalized in M2 and unchanged here)
+
+## Context
+
+TASK-103a picked bounded, block-on-full, capacity 1,024 as a provisional default purely so early
+benchmarks would be comparable, explicitly deferring the real decision to TASK-306 once M3's
+benchmark data existed. `AGENTS.md` gates any change to this default on that data. ADR-004 already
+settled the *qualitative* policy question (overflow blocks; it does not reject, drop, or fail) —
+what TASK-306 has left to confirm or replace is the *specific* capacity value, using TASK-301,
+TASK-302, and TASK-307's data as `mailbox-bounds-provisional.md` said it would.
+
+There was a gap in that data going in: TASK-301/302's busiest workload (16 concurrent senders
+against one actor) never drives a mailbox anywhere near capacity 1,024 — those benchmarks show how
+the runtime behaves well below the limit, not what the limit itself costs or buys. TASK-306 closes
+that gap directly rather than deciding from data that never actually exercised backpressure.
+
+## What was built and measured
+
+`BoundedBlockingMailbox` (in the `benchmarks` module, not wired into `framework-core`) is a
+faithful copy of `framework-core`'s package-private `Mailbox` — same fair-lock, same
+`ArrayDeque`-backed design — parameterized by capacity, since the real `Mailbox`'s capacity isn't
+part of `framework-core`'s public API. `BoundedBlockingMailboxTest` proves it behaves identically
+(FIFO order, blocks while full, capacity enforced) before trusting any number from it — the same
+discipline TASK-303's `SharedPoolActorCell` established.
+
+Two new measurements, at capacities 16 / 128 / 1,024 / 8,192:
+
+1. **`MailboxBackpressureBenchmark`** — a consumer deliberately throttled to ~1 message/ms (far
+   slower than 8 concurrent senders can produce), so the mailbox is genuinely saturated throughout
+   the measurement, not just occasionally full. Measures accepted messages/sec and per-call
+   `offer()` blocking latency distribution — the actual backpressure a sender feels.
+2. **A fourth `MemoryFootprintHarness` scenario** — mailboxes filled to exactly their capacity with
+   a single shared sentinel message (isolating the backing array's cost from per-message payload
+   size, which TASK-307's other scenarios already cover and which the framework doesn't control
+   anyway), sampled at rest.
+
+## Results
+
+**Throughput and blocking latency are invariant to capacity once the mailbox is actually
+saturated:**
+
+| Capacity | Accepted throughput | Mean `offer()` latency |
+|---|---|---|
+| 16 | 980.65 ops/s | 8,155.15 µs |
+| 128 | 974.91 ops/s | 8,139.51 µs |
+| 1,024 | 977.95 ops/s | 8,146.41 µs |
+| 8,192 | 978.11 ops/s | 8,144.25 µs |
+
+This is exactly what queueing theory predicts and what this benchmark was built to confirm rather
+than assume: once arrivals exceed a fixed service rate, steady-state acceptance throughput is
+capped by the consumer's rate, and average blocking latency is governed by the fair lock's arrival
+order divided by that same rate — neither depends on how big the buffer is. Capacity's only real
+effect is how much bursty demand can be absorbed before backpressure kicks in at all, and how much
+memory is retained while saturated.
+
+**Memory scales with capacity, but only when a mailbox is actually filled that far** — extending
+TASK-307's finding that an idle mailbox's backing array only pre-sizes to `min(capacity, 256)` and
+grows lazily:
+
+| Capacity | Retained bytes per mailbox, fully saturated |
+|---|---|
+| 16 | 250 |
+| 128 | 700 |
+| 1,024 | 5,398 |
+| 8,192 | 40,184 |
+
+Growth is roughly linear in capacity once saturated (as expected — the backing array's size is the
+dominant cost), at roughly 5 bytes per queued-slot. At the current default, a *fully saturated*
+actor costs about 5.4 KB — barely more than TASK-307's idle-actor baseline (~3.2 KB) — so even
+10,000 actors all saturated simultaneously (a pathological worst case; TASK-301/302 never came
+close to producing it) would cost roughly 54 MB. At 8,192 the same worst case would cost roughly
+400 MB — a real, measured cost for headroom nothing tested here needed.
+
+## Decision
+
+**Confirm the current default: bounded mailbox, block-on-full, capacity 1,024.** No change to
+`framework-core`'s behavior.
+
+* **Block-on-full is unchanged and unchallenged** — nothing in this data argues for reject, drop,
+  or fail; blocking remains the only policy that never silently loses a message, and switching
+  would mean re-litigating ADR-004's already-formalized semantics for no measured benefit.
+* **1,024 is confirmed, not just left alone by default** — the data rules out the two directions a
+  change could go:
+  * *Raising it* (e.g. to 8,192) buys burst-absorption headroom nothing tested here has needed —
+    TASK-301/302's realistic workloads never approach even the current limit — while measurably
+    increasing worst-case per-actor memory under sustained overload (~7.4× at 8,192 vs. 1,024).
+  * *Lowering it* (e.g. to 128 or 16) saves memory that is already negligible next to an actor's
+    other fixed costs (TASK-307: mailbox capacity contributes only a few hundred bytes at most
+    realistic depths, dwarfed by the ~3 KB baseline from `ActorCell`, its thread, and registry
+    entry) while reducing burst-absorption headroom for no measured gain.
+* 1,024 is therefore a reasonable, now-confirmed middle ground: cheap even in the pathological
+  worst case, with meaningful slack for realistic bursts.
+
+## What this does not cover
+
+* **No realistic workload benchmarked here has ever actually approached capacity 1,024.** This ADR
+  confirms the default is *safe and inexpensive* under genuine saturation, not that 1,024
+  specifically is *optimal* for some higher-scale production pattern this project hasn't measured
+  yet. If a real workload is ever found that habitually saturates the mailbox, that is new data
+  this ADR does not have, and would warrant revisiting — with that data, not speculatively.
+* **Per-actor configurable capacity was deliberately not added.** TASK-306 is about confirming or
+  replacing the one hardcoded default, not about exposing capacity as a new tunable — that is a
+  separate, undecided API-surface question (raised, not settled, here) that would need its own
+  ADR if a concrete need for it ever arises.
+* Measured on the same 4-core, shared/virtualized sandbox as every other benchmark in this suite —
+  the *shape* of the results (capacity-invariant throughput/latency; linear memory scaling only
+  under saturation) is expected to generalize; the exact numbers would differ on other hardware.
+
+## Consequences
+
+* No change to `framework-core`'s behavior. `Mailbox.DEFAULT_CAPACITY` remains 1,024; the
+  "provisional" language in `Mailbox`'s Javadoc and `docs/architecture.md` §4 is updated to record
+  that this is now a confirmed decision, not a placeholder.
+* `docs/decisions/mailbox-bounds-provisional.md` is retained as the historical record of the
+  provisional decision, with a note pointing here.
+* `BoundedBlockingMailbox`, `MailboxBackpressureBenchmark`, and the fourth `MemoryFootprintHarness`
+  scenario remain in the `benchmarks` module as the recorded comparison point, the same way
+  TASK-303's harness remains available if dispatch strategy is ever revisited.
+* Any future change to the mailbox's bounds or backpressure policy must engage with this ADR's
+  data explicitly, or supersede it with new data of its own — it does not get changed casually.

--- a/docs/decisions/mailbox-bounds-provisional.md
+++ b/docs/decisions/mailbox-bounds-provisional.md
@@ -1,9 +1,11 @@
 # Provisional decision: mailbox bounds (TASK-103a)
 
-**This is not an ADR.** It is a placeholder decision, recorded so it is visible and so the M3
-benchmarks and the Day-1 experiment (Section 18 of the design document) measure a consistent,
-known policy instead of whatever was fastest to implement. It is superseded by TASK-306's own ADR
-(M3), once real benchmark data exists.
+**This is not an ADR. It is now superseded by
+[ADR-007](ADR-007-mailbox-bounds-confirmed.md) (TASK-306),** which confirms the decision recorded
+here with real benchmark data. This note is kept as the historical record of the placeholder
+decision; it was recorded so that the M3 benchmarks and the Day-1 experiment (Section 18 of the
+design document) would measure a consistent, known policy instead of whatever was fastest to
+implement.
 
 ## The decision
 
@@ -29,9 +31,10 @@ compare against later once TASK-306 changes the policy again.
   poison-message, and rejected-message semantics are formally specified in TASK-203's
   `docs/decisions/ADR-004-mailbox-overflow-poison-rejection-semantics.md`.
 
-## What happens next
+## What happened next
 
-TASK-306 (M3) revisits this in light of the M3 benchmarks (TASK-301, TASK-302, TASK-307) and
-either confirms or replaces it, written up as its own ADR. Until then, do not change this
-default without updating this note and flagging that the M3 benchmarks it fed may need
-re-running.
+TASK-306 (M3) revisited this in light of the M3 benchmarks (TASK-301, TASK-302, TASK-307) plus a
+new benchmark built specifically to drive the mailbox to real backpressure, since none of the
+existing ones did. **The decision recorded here is confirmed, not replaced:** bounded, block-on-
+full, capacity 1024. See [ADR-007](ADR-007-mailbox-bounds-confirmed.md) for the data and reasoning.
+Any future change to this default now needs its own ADR that engages with ADR-007's data.

--- a/framework-core/src/main/java/dev/actorframework/core/Mailbox.java
+++ b/framework-core/src/main/java/dev/actorframework/core/Mailbox.java
@@ -7,11 +7,11 @@ import java.util.concurrent.locks.ReentrantLock;
 /**
  * The FIFO queue of messages waiting to be processed by a single actor (TASK-103).
  *
- * <p><b>Provisional bounds decision (TASK-103a):</b> the mailbox is bounded with a generous default
- * capacity and blocks the sending thread when full ("block-on-full"). This is a deliberately
- * provisional default, chosen only so that early benchmarks and the Day-1 experiment (Section 18)
- * are comparable; it is revisited with real measurements at TASK-306 and recorded in {@code
- * docs/decisions/mailbox-bounds-provisional.md}. Do not treat this policy as final.
+ * <p><b>Bounds confirmed with benchmark data (TASK-306):</b> the mailbox is bounded with a default
+ * capacity and blocks the sending thread when full ("block-on-full"). TASK-103a chose this only so
+ * early benchmarks and the Day-1 experiment (Section 18) would be comparable; TASK-306 confirmed
+ * both the policy and the specific default capacity against real backpressure data. See {@code
+ * docs/decisions/ADR-007-mailbox-bounds-confirmed.md}.
  *
  * <p>Thread safety: {@link #offer} may be called concurrently by many sender threads. {@link #take}
  * is called by exactly one thread — the actor's dedicated dispatcher thread (TASK-105) — which is
@@ -30,7 +30,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 final class Mailbox<T> {
 
-  /** Provisional default capacity (TASK-103a) — not yet backed by benchmark data. */
+  /** Default capacity, confirmed by benchmark data (TASK-306, ADR-007). */
   static final int DEFAULT_CAPACITY = 1024;
 
   private final ArrayDeque<T> queue;


### PR DESCRIPTION
Closes #18.

## Why

TASK-103a picked bounded, block-on-full, capacity 1024 as an explicitly provisional mailbox
default, deferring the real decision to TASK-306 once M3's benchmark data existed. TASK-301 and
TASK-302's benchmarks don't fully supply that data on their own: their busiest workload (16
concurrent senders against one actor) never drives a mailbox anywhere near capacity 1024, so they
show how the runtime behaves well below the limit, not what the limit itself costs or buys. This PR
closes that gap with two purpose-built measurements before writing the ADR.

## What was built

* **`BoundedBlockingMailbox`** (`benchmarks/src/main/java`) — a faithful, parameterized copy of
  `framework-core`'s package-private `Mailbox`, since the real `Mailbox`'s capacity isn't public
  API. `BoundedBlockingMailboxTest` proves it behaves identically (FIFO order, blocks while full,
  capacity enforced, unblocks on `close()`) before any benchmark number from it is trusted — same
  discipline as TASK-303's `SharedPoolActorCell`. Deliberately **not** wired into `framework-core`.
* **`MailboxBackpressureBenchmark`** (JMH) — a consumer deliberately throttled to ~1 message/ms
  against 8 concurrent senders, so the mailbox is genuinely saturated throughout the run, not just
  occasionally full. Measures accepted throughput and `offer()` blocking latency at capacities 16,
  128, 1024, 8192.
* A fourth **`MemoryFootprintHarness`** scenario — mailboxes filled to exactly their capacity with a
  single shared sentinel message, isolating the backing array's cost from per-message payload size.

## Results

Throughput and blocking latency, once saturated, are **invariant to capacity**:

| Capacity | Accepted throughput | Mean `offer()` latency |
|---|---|---|
| 16 | 980.65 ops/s | 8,155.15 µs |
| 128 | 974.91 ops/s | 8,139.51 µs |
| 1,024 | 977.95 ops/s | 8,146.41 µs |
| 8,192 | 978.11 ops/s | 8,144.25 µs |

Exactly as queueing theory predicts: once arrivals exceed a bottlenecked consumer's fixed service
rate, both acceptance throughput and average blocking latency are capped by that rate, independent
of buffer size.

Retained memory **scales roughly linearly with capacity, but only once actually saturated**:

| Capacity | Retained bytes per mailbox, fully saturated |
|---|---|
| 16 | 250 |
| 128 | 700 |
| 1,024 | 5,398 |
| 8,192 | 40,184 |

The current default costs only ~5.4 KB per actor even fully saturated — barely more than TASK-307's
idle-actor baseline (~3.2 KB) — so even 10,000 actors saturated simultaneously (a pathological
worst case none of TASK-301/302's realistic workloads produced) would cost roughly 54 MB.

## Decision (ADR-007)

**Confirm the current default: bounded mailbox, block-on-full, capacity 1024.** No behavior change
to `framework-core`. Full reasoning, including what this data does *not* cover (no realistic
workload tested here ever approaches capacity 1024; per-actor configurable capacity was
deliberately not added as part of this decision), is in
`docs/decisions/ADR-007-mailbox-bounds-confirmed.md`.

## Docs updated

* New: `docs/decisions/ADR-007-mailbox-bounds-confirmed.md`
* `docs/decisions/mailbox-bounds-provisional.md` — marked superseded by ADR-007
* `docs/architecture.md` §4 (Mailbox) — references the confirmed decision
* `AGENTS.md` — "Mailbox bounds / backpressure policy" gate updated to reflect resolution
* `framework-core/.../Mailbox.java` — javadoc updated from "provisional" to "confirmed" (comments
  only, no behavior change)
* `benchmarks/README.md` — new TASK-306 section

## Verification

* `BoundedBlockingMailboxTest`'s 4 correctness tests pass
* `./gradlew clean build` passes (full multi-module build, including `benchmarks`)
* `./gradlew :benchmarks:jmh` and `./gradlew :benchmarks:memoryFootprint` run successfully; all
  numbers above are real measured output, not projected

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp)_