### PR TITLE
TASK-308: measure actor spawn cost

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -21,6 +21,7 @@ Standard JMH command-line options can be passed through, e.g. to run one benchma
 ./gradlew :benchmarks:jmh -Pjmh.includes=MessagingLatencyDistributionBenchmark
 ./gradlew :benchmarks:jmh -Pjmh.includes=SharedPoolDispatchBenchmark
 ./gradlew :benchmarks:jmh -Pjmh.includes=MailboxBackpressureBenchmark
+./gradlew :benchmarks:jmh -Pjmh.includes=ActorSpawnBenchmark
 ```
 
 TASK-307's memory-footprint measurement is not a JMH benchmark (see below for why) and runs via its
@@ -152,4 +153,22 @@ Decision: **confirm** the current default — bounded, block-on-full, capacity 1
 `framework-core`. See `docs/decisions/ADR-007-mailbox-bounds-confirmed.md` for the full reasoning,
 including what this data does and doesn't cover.
 
-TASK-308 is not yet implemented; see the open issues for what remains.
+## TASK-308: actor spawn cost
+
+None of TASK-301/302/306/307 isolate the cost of `ActorSystem.spawn()` itself: TASK-301's
+`ActorCountScalabilityBenchmark` spawns its actors once in `@Setup`, outside the timed benchmark,
+and every other benchmark in the suite spawns a single already-warm actor before measuring
+anything. ADR-002 names an open question this leaves unanswered — "actor count is currently
+bounded only by how many virtual threads (and their associated mailboxes) the JVM can hold" — from
+the per-operation-cost side; TASK-307 already covers the standing-memory side.
+
+`ActorSpawnBenchmark` measures spawn directly. Each operation pairs a spawn with an immediate stop
+request so a long-running measurement doesn't accumulate an unbounded number of live actors and
+their virtual threads — requesting a stop before any message is ever sent lets that actor's
+dispatch loop see a closed, empty mailbox and exit almost as soon as it's scheduled, so the pair's
+cost is dominated by spawn, not by the (much cheaper) stop request itself:
+
+* `spawnThroughputUnderLoad` — spawns/sec sustained under 16 concurrent spawning threads.
+* `spawnLatencyUncontended` — full spawn-latency distribution (p50/p95/p99/p999), single-threaded.
+* `spawnLatencyUnderLoad` — the same distribution under the same 16-thread contended load as
+  `spawnThroughputUnderLoad`.

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -5,6 +5,11 @@
 // actor, and how that cost holds up as the number of live actors grows. This is the real
 // measurement data TASK-303 (dispatcher alternatives) and TASK-306 (mailbox bounds) are gated on
 // before either is revisited.
+//
+// TASK-308 measures the one operation none of TASK-301/302/306/307 isolate: the cost of
+// ActorSystem.spawn() itself, closing ADR-002's other open question ("actor count is bounded
+// only by how many virtual threads the JVM can hold") from the per-spawn-cost side, alongside
+// TASK-307's standing-memory-per-actor side.
 
 plugins {
     id("me.champeau.jmh") version "0.7.3"

--- a/benchmarks/src/jmh/java/dev/actorframework/benchmarks/ActorSpawnBenchmark.java
+++ b/benchmarks/src/jmh/java/dev/actorframework/benchmarks/ActorSpawnBenchmark.java
@@ -1,0 +1,92 @@
+package dev.actorframework.benchmarks;
+
+import dev.actorframework.core.ActorRef;
+import dev.actorframework.core.ActorSystem;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * TASK-308: measures the cost of {@link ActorSystem#spawn} itself.
+ *
+ * <p>None of TASK-301/302/306/307 isolate this: {@code ActorCountScalabilityBenchmark} (TASK-301)
+ * spawns its {@code actorCount} actors once in {@code @Setup}, outside the timed benchmark, and
+ * every other benchmark in the suite spawns a single already-warm actor before measuring anything.
+ * ADR-002 defers exactly this question — "actor count is currently bounded only by how many virtual
+ * threads (and their associated mailboxes) the JVM can hold" — to real measurement rather than
+ * guessing; this benchmark supplies the per-spawn-operation half of that answer (TASK-307 already
+ * supplies the standing-memory-per-actor half).
+ *
+ * <p>Each operation pairs a spawn with an immediate stop request, so a long-running measurement
+ * doesn't accumulate an unbounded number of live actors and their virtual threads. Requesting a
+ * stop before any message is ever sent lets that actor's dispatch loop see a closed, empty mailbox
+ * and exit almost as soon as it's scheduled, so the pair's cost is dominated by spawn — allocating
+ * an {@code ActorCell} and {@code Mailbox}, registering the actor, and starting its dedicated
+ * virtual thread — not by the stop request itself (a single compare-and-set plus a queue close).
+ */
+@State(Scope.Benchmark)
+@Fork(2)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class ActorSpawnBenchmark {
+
+  private static final int CONTENDED_SPAWNER_THREADS = 16;
+
+  private ActorSystem system;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    system = ActorSystem.start("actor-spawn-benchmark");
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    system.close();
+  }
+
+  /** Spawns/sec sustained under concurrent spawning. */
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  @Threads(CONTENDED_SPAWNER_THREADS)
+  public void spawnThroughputUnderLoad() {
+    spawnAndStop();
+  }
+
+  /** Full spawn-latency distribution (p50/p95/p99/p999), uncontended. */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Threads(1)
+  public void spawnLatencyUncontended() {
+    spawnAndStop();
+  }
+
+  /**
+   * Full spawn-latency distribution (p50/p95/p99/p999) under the same contended spawning load as
+   * {@link #spawnThroughputUnderLoad}.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Threads(CONTENDED_SPAWNER_THREADS)
+  public void spawnLatencyUnderLoad() {
+    spawnAndStop();
+  }
+
+  private void spawnAndStop() {
+    ActorRef<Object> actor = system.spawn(() -> (context, message) -> {});
+    system.stop(actor);
+  }
+}


### PR DESCRIPTION
Closes #20.

## Why

TASK-308's own issue text doesn't pin down what it should measure beyond "part of the JMH suite
grouped in `benchmarks/build.gradle.kts` with TASK-301/302/307" — it points to a "Section 18" of
the original design document, which isn't checked into this repo. Looking at what TASK-301,
TASK-302, TASK-306, and TASK-307 already cover:

* TASK-301 — dispatch round-trip cost, and throughput as actor count scales (but actors are all
  spawned once in `@Setup`, outside the timed benchmark)
* TASK-302 — messaging throughput and full latency-percentile distribution
* TASK-306 — mailbox bounds/backpressure cost
* TASK-307 — standing (idle) per-actor memory footprint

None of them isolate the cost of `ActorSystem.spawn()` itself. ADR-002 names an open question this
leaves unanswered — "actor count is currently bounded only by how many virtual threads (and their
associated mailboxes) the JVM can hold" — from the per-operation-cost side; TASK-307 already covers
the standing-memory side. TASK-308 closes that gap.

## What was built

`ActorSpawnBenchmark` (JMH) measures spawn directly. Each operation pairs a spawn with an immediate
stop request so a long-running measurement doesn't accumulate an unbounded number of live actors
and their virtual threads: requesting a stop before any message is ever sent lets that actor's
dispatch loop see a closed, empty mailbox and exit almost as soon as it's scheduled, so the pair's
cost is dominated by spawn — allocating an `ActorCell`/`Mailbox`, registering the actor, and
starting its dedicated virtual thread — not by the (much cheaper) stop request itself.

* `spawnThroughputUnderLoad` — spawns/sec sustained under 16 concurrent spawning threads.
* `spawnLatencyUncontended` — full spawn-latency distribution (p50/p95/p99/p999), single-threaded.
* `spawnLatencyUnderLoad` — the same distribution under the same 16-thread contended load.

## Results (local run)

* `spawnThroughputUnderLoad`: ~742K spawns/sec under 16 concurrent spawning threads
* `spawnLatencyUncontended`: mean ~18µs/op (p50 ~14µs, p99 ~68µs, p999 ~186µs)
* `spawnLatencyUnderLoad`: mean ~30µs/op, with a long right tail under contention, as expected

## Docs updated

* `benchmarks/README.md` — new TASK-308 section, plus the `jmh.includes` example list
* `benchmarks/build.gradle.kts` — top-of-file comment now describes what TASK-308 measures

## Verification

* `./gradlew clean build` passes (full multi-module build, including `benchmarks`)
* `./gradlew :benchmarks:jmh -Pjmh.includes=ActorSpawnBenchmark` run successfully; the numbers
  above are real measured output, not projected

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp)_