### PR TITLE
Codify regression-test policy for bug fixes and add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+Closes #<!-- issue number, if any -->
+
+## Why
+
+<!-- What problem this solves or question it answers. Link the TASK/ADR/issue it closes or informs. -->
+
+## What was built
+
+<!-- The change itself, in enough detail for a reviewer who hasn't read the issue: new types/files,
+behavior changed, alternatives considered and rejected. -->
+
+## Results
+
+<!-- For anything backed by a benchmark, experiment, or bug repro: the actual measured output, not
+projected numbers. Delete this section if not applicable. -->
+
+## Regression test
+
+<!-- Required for bug fixes (see AGENTS.md "Testing requirements"): name the test that reproduces
+the bug and fails against the pre-fix code. Delete this section for non-bug-fix PRs. -->
+
+## Docs updated
+
+<!-- List every doc/ADR/README touched, or state "none needed" and why. -->
+
+## Verification
+
+- [ ] `./gradlew build` passes
+<!-- any other manual verification: benchmark run, example run, etc. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ milestone that actually needs them.
   happy-path tests.
 * Run `./gradlew build` before considering any change to `framework-core` or `framework-testkit`
   done.
+* **Bug fixes always come with a regression test.** Write the test first so it fails against the
+  pre-fix code, then land the fix — test and fix in the same commit/PR, not a follow-up.
 
 ## Things that require a new ADR before changing, not a silent code change
 

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -51,6 +51,8 @@ relevant TASK/ADR — the code and the decision record should never drift apart 
 * `framework-core` tests may reach into package-private internals (e.g. `Mailbox`) directly,
   since they live in the same package. Tests for anything outside `framework-core` use the
   public API only.
+* Every bug fix ships with a regression test that reproduces the bug — it fails against the
+  pre-fix code and passes once the fix lands — in the same change, never deferred to a follow-up.
 
 ## Benchmarking expectations
 


### PR DESCRIPTION
## Why

Asked what this repo's policy is for a discovered bug, the honest answer was "there's no written
rule, but the existing testing philosophy (every guarantee needs a test that would fail if broken)
clearly implies it, and it's what I actually did in practice here (TASK-303/306 built
`SharedPoolActorCellTest`/`BoundedBlockingMailboxTest` to prove new infrastructure correct before
trusting any number from it)." Writing that down instead of leaving it implicit, and separately,
this repo has never had a PR template — recent PRs (#29-#36) converged informally on the same
Why/What was built/Results/Docs updated/Verification shape without anything enforcing it.

## What was built

* `AGENTS.md` — new bullet under "Testing requirements": every bug fix ships with a regression
  test that fails against the pre-fix code and passes after the fix, landing in the same
  commit/PR, not a follow-up.
* `docs/coding-standards.md` — matching bullet under "Testing expectations".
* `.github/pull_request_template.md` — new. Mirrors the shape recent PRs already used, plus a
  "Regression test" section for bug-fix PRs that points back at the policy above.

No `framework-core`/`framework-testkit`/`benchmarks` code touched — docs and repo config only.

## Docs updated

* `AGENTS.md`
* `docs/coding-standards.md`
* `.github/pull_request_template.md` (new)

## Verification

* `./gradlew build` passes (full multi-module build)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp)_