### PR TITLE
TASK-402: configurable supervision strategies and actor hierarchies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,13 @@ risks invalidating work upstream or downstream of the change:
 * **What happens to queued messages when an actor stops** (currently: discarded, not delivered).
 * **The dispatch strategy** (currently: one dedicated virtual thread per actor for its whole
   lifetime). Alternatives are evaluated with benchmarks at TASK-303 (M3), not swapped in ad hoc.
-* **The minimal failure-handling default** (TASK-107a: log and stop that actor alone). This is
-  intentionally not configurable in M1 — configurable supervision arrives in M4 (TASK-402) and
-  supersedes this, but it doesn't get quietly extended before then.
+* **The failure-handling default.** TASK-107a's fixed "log and stop that actor alone" was
+  intentionally not configurable in M1, and has since been superseded by configurable supervision
+  strategies and actor hierarchies at TASK-402
+  (`docs/decisions/ADR-008-supervision-strategies-and-hierarchies.md`) — a top-level actor still
+  gets exactly TASK-107a's behavior, unconfigurable, but any future change to that, to the four
+  supervision directives, or to hierarchy/cascade semantics needs a new ADR that engages with
+  ADR-008, not a silent edit.
 * **Anything touching the pre-M10 trust boundary** — see `docs/decisions/ADR-000-*.md`. Before
   M10's real security work (TASK-1007), no transport or cluster component may bind to anything
   other than localhost by default, and none may be documented or marketed as safe for an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,6 @@
 # Architecture
 
-Status: living document, updated as milestones land. Current milestone: **M1 — Minimal Actor
-Runtime**.
+Status: living document, updated as milestones land. Current milestone: **M4 — Supervision**.
 
 ## 1. Actor model
 
@@ -85,7 +84,10 @@ stops while it is waiting. See
    thread, which calls `preStart` and then enters the message loop.
 2. An actor stops when:
    * `ActorSystem.stop(ref)` is called explicitly, or
-   * an uncaught exception escapes `preStart` or `onMessage` (see "Failure handling" below), or
+   * an uncaught exception escapes `preStart` or `onMessage` and its `SupervisorStrategy` decides
+     `Stop` or `Escalate` (see "Failure handling" below), or
+   * its supervisor (parent) stops, or an `Escalate` decision elsewhere in its ancestor chain
+     cascades a stop down to it (TASK-402), or
    * the owning `ActorSystem` shuts down.
 3. On stop, the mailbox is closed immediately: any messages still queued at that moment are
    **rejected, not delivered** (see "Mailbox," above), and any sender currently blocked in
@@ -102,30 +104,56 @@ This is a deliberately simple stop model for M1: no draining, no "let the mailbo
 first" mode. `ActorSystem.close()` (or the try-with-resources form) stops every actor and blocks
 until all of them have finished terminating.
 
-## 6. Failure handling (TASK-107a)
+## 6. Actor hierarchies (TASK-402)
 
-There is one, non-configurable default for M1: if `onMessage` (or `preStart`) throws, the
-failure is logged with the actor's identity and the message being processed, and *that actor
-alone* is stopped, following the normal lifecycle above. No other actor, and not the
-`ActorSystem` itself, is affected — this holds structurally, because each actor runs on its own
-thread and failures never cross that boundary.
+An actor may spawn children of its own from within `preStart`/`onMessage`, via
+`ActorContext.spawnChild(factory, name[, strategy])`, becoming their supervisor. A child's id is
+namespaced under its parent's (`parent.id() + "/" + name`). A **top-level actor** (spawned via
+`ActorSystem.spawn`) has no parent and always behaves exactly as TASK-107a originally specified
+— see "Failure handling," below; only a spawned child gets a configurable `SupervisorStrategy`.
 
-**Poison message (TASK-203):** the message whose processing triggers this — the one `onMessage`
-or `preStart` was handling when it threw — is termed a poison message. Because M1–M3 have no
-redelivery or retry mechanism, a poison message structurally cannot cause a retry loop: it is
-processed at most once, the actor stops, and the message is never redelivered to this or any
-other actor. This guarantee holds only through M1–M3; M4 (TASK-402) must explicitly re-examine
-whether a restarted actor can receive the same poison message again. See
-`docs/decisions/ADR-004-mailbox-overflow-poison-rejection-semantics.md`.
+Stopping an actor stops every actor it supervises, transitively — a supervisor's children (and
+their own children, and so on) always go with it. This applies uniformly whether the stop was
+requested explicitly (`ActorSystem.stop`), came from a `Stop` directive (below), or cascaded down
+from a stop somewhere above it in the hierarchy.
 
-This is a safety net, not the supervision model. Configurable strategies (Resume, Restart, Stop,
-Escalate) and actor hierarchies arrive in M4 (TASK-402).
+## 7. Failure handling (TASK-107a, TASK-402)
 
-## 7. API philosophy
+**Top-level actors are unchanged from M1:** if `preStart`/`onMessage` throws, the failure is
+logged and *that actor alone* is stopped, following the normal lifecycle above. This remains
+non-configurable for a top-level actor — becoming a supervisor (spawning children) is how an
+actor gets access to the configurable behavior below.
+
+**A child actor's failure is handled by the `SupervisorStrategy` it was given at spawn time** (a
+plain, stateless function of the failure — consulted only by the failing actor itself, on its own
+dispatcher thread), choosing one of four directives:
+
+* **Resume** — the actor keeps its existing state and keeps running, as if nothing happened.
+* **Restart** — the actor is replaced with a fresh instance (state reset); `preRestart`/
+  `postRestart` hooks run around the swap, best-effort.
+* **Stop** — the actor stops, following the normal lifecycle (and cascades to its own children,
+  per "Actor hierarchies," above) — TASK-107a's old default, now one of four choices rather than
+  the only one.
+* **Escalate** — the actor stops, and so does its entire ancestor chain up to the root (each
+  ancestor's own stop cascading back down to *its* children too). An actor with no parent stops on
+  its own, same as `Stop`.
+
+**Poison message (TASK-203):** the message whose processing triggers a failure — the one
+`onMessage` or `preStart` was handling when it threw — is termed a poison message. It is always
+processed at most once and never redelivered, **including under `Restart`**: `Mailbox.take()`
+already removes a message before `onMessage` (or the failure) happens, so there is nothing left in
+the mailbox to redeliver by the time any `SupervisorStrategy` is even consulted. See
+`docs/decisions/ADR-004-mailbox-overflow-poison-rejection-semantics.md` and
+`docs/decisions/ADR-008-supervision-strategies-and-hierarchies.md` for the full derivation and
+semantics (including what this deliberately does not cover: restart rate-limiting, and dynamic
+re-supervision on `Escalate`).
+
+## 8. API philosophy
 
 * Small core, own the stack, local-first.
-* Complexity is opt-in: nothing beyond `ActorSystem`, `ActorRef`, `Actor`, `Mailbox`, and
-  `Dispatcher` exists yet, on purpose.
+* Complexity is opt-in: an actor only gets configurable supervision by choosing to spawn children
+  (`ActorContext.spawnChild`); a plain top-level actor still behaves exactly like M1's fixed
+  default, with nothing extra to learn or configure.
 * No API is finalized until proven through implementation and tests — in particular, `ask()`
   does not exist yet; it is designed in ADR-015 (M5) before it is added.
 

--- a/docs/decisions/ADR-004-mailbox-overflow-poison-rejection-semantics.md
+++ b/docs/decisions/ADR-004-mailbox-overflow-poison-rejection-semantics.md
@@ -94,3 +94,17 @@ scope for this ADR — YAGNI until a caller exists that can observe the differen
 * Any future change to overflow policy (TASK-306), failure handling (TASK-402), or send semantics
   (`ask()`, M5) that alters what "poison message" or "rejected message" means must supersede this
   ADR explicitly, per the ADR-required list in `AGENTS.md`.
+
+## Resolved at TASK-402 (ADR-008)
+
+TASK-402 introduced configurable supervision, including `Directive.RESTART`, and — as flagged
+above — had to explicitly re-examine whether a restarted actor can receive the same poison message
+again. **It cannot.** This is not a policy choice TASK-402 made; it is mechanically guaranteed by
+`Mailbox` unchanged since M1: `Mailbox.take()` removes a message from the queue *before* returning
+it, and `onMessage` (or the failure it throws) only happens after that removal. By the time a
+failure occurs — and therefore by the time any `SupervisorStrategy`, including `RESTART`, is even
+consulted — the poison message is already gone from the mailbox. Restarting swaps the actor
+instance and resumes consumption with whatever is next in the queue, if anything; there is nothing
+left to redeliver. The "processed at most once, never redelivered" guarantee above holds unchanged
+by `RESTART`, and no longer needs the "this guarantee holds only through M1–M3" caveat. See
+`docs/decisions/ADR-008-supervision-strategies-and-hierarchies.md` for full supervision semantics.

--- a/docs/decisions/ADR-005-jmm-review-sequential-processing.md
+++ b/docs/decisions/ADR-005-jmm-review-sequential-processing.md
@@ -154,3 +154,27 @@ swapping the mailbox's lock for something that doesn't provide the same happens-
 * Any future change to `Mailbox`'s synchronization strategy, or to the one-thread-per-actor
   dispatch strategy (TASK-303, M3), must re-derive these happens-before edges explicitly rather
   than assume they still hold — this ADR is the checklist for that re-derivation.
+
+## Addendum (TASK-402): `actor` is no longer `final`
+
+§5 above lists `actor` among the fields whose `final`-ness contributes to safe publication. TASK-402
+(configurable supervision) needs `Directive.RESTART` to replace an actor's instance in place, so
+`ActorCell.actor` dropped `final`. This does not reopen §5's conclusion, for two independent
+reasons:
+
+* The *initial* instance's safe publication to the dispatcher thread never actually needed
+  `final` — the `Executor.execute()` happens-before edge (the second, independent guarantee §5
+  already names) covers *every* field write the constructing thread made before submitting
+  `cell::run`, not only writes to `final` fields. Losing `final` on this one field does not remove
+  that edge.
+* Every *subsequent* write to `actor` (each `RESTART`) happens inside
+  `ActorCell.handleFailureAndDecideContinue`, which — like `preStart`/`onMessage`/`postStop` before
+  it — only ever runs on this cell's own dispatcher thread (it is reached from `run()` and
+  `dispatchLoop()`, both already confirmed single-threaded per §1). So every write and every
+  subsequent read of `actor` after construction happens in program order on that one thread — the
+  same "no second thread involved" reasoning §1 already gives actor-owned state, not a new
+  cross-thread visibility question.
+
+No other field's safe-publication story changes. `ActorRefImpl` and `ActorContextImpl` still never
+read `actor` directly. See `docs/decisions/ADR-008-supervision-strategies-and-hierarchies.md` for
+the full supervision design.

--- a/docs/decisions/ADR-008-supervision-strategies-and-hierarchies.md
+++ b/docs/decisions/ADR-008-supervision-strategies-and-hierarchies.md
@@ -1,0 +1,143 @@
+# ADR-008: Configurable supervision strategies and actor hierarchies (TASK-402)
+
+* Status: Accepted
+* Written during: M4 (TASK-402)
+* Supersedes: TASK-107a's fixed failure-handling default, per the ADR-gate `AGENTS.md` places on
+  it — see below for exactly what changes and what doesn't.
+* Builds on: ADR-004 (poison-message semantics — resolves its flagged open question), ADR-005
+  (JMM review — see its TASK-402 addendum for the one field this touches)
+
+## Context
+
+M1 shipped one fixed default (TASK-107a): if `preStart`/`onMessage` throws, the failure is logged
+and *that actor alone* stops. `docs/architecture.md` §6 named this "a safety net, not the
+supervision model" from the start, and committed M4 to adding the four directives real actor
+frameworks use — **Resume, Restart, Stop, Escalate** — plus actor hierarchies, since
+`ActorContext` had no parent/child concept at all until now.
+
+This also resolves a question ADR-004 explicitly deferred here: whether a restarted actor can
+receive the same poison message again. See ADR-004's own "Resolved at TASK-402" addendum for the
+answer (no, mechanically guaranteed by `Mailbox.take()`'s existing dequeue-before-processing
+order) — not repeated in full here.
+
+**Escalate's scope was decided deliberately narrow, up front**, to avoid inventing concurrency
+machinery this project doesn't have a proven need for yet (see "What this deliberately does not
+cover," below).
+
+## Decision
+
+### Top-level actors are unchanged
+
+`ActorSystem.spawn(...)` keeps its exact existing signature. Internally, a top-level actor's
+`ActorCell` is always constructed with `parent = null` and `strategy = SupervisorStrategy.stop()`
+— byte-for-byte TASK-107a's old default: log and stop alone, nothing configurable at this level.
+Every existing test and example (`ActorFailureTest`, `ActorSystemTest`, `hello-world`,
+`ping-pong`) needed zero changes, which is itself the regression signal that this holds.
+
+Real supervision only exists for actors spawned via the new `ActorContext.spawnChild(...)` — an
+actor becomes a supervisor only by choosing to spawn children.
+
+### Hierarchies
+
+`ActorContext<T>` gains:
+
+```java
+<C> ActorRef<C> spawnChild(Supplier<Actor<C>> factory, String name); // defaults to stop()
+<C> ActorRef<C> spawnChild(Supplier<Actor<C>> factory, String name, SupervisorStrategy strategy);
+```
+
+A child's id is namespaced under its parent's: `parent.id() + "/" + name"`, reusing the same flat
+`ActorSystem.actors` registry top-level actors already use — no new lookup structure. **Known,
+accepted limitation:** a top-level actor literally named e.g. `"parent/child"` could collide with
+a real child `"child"` spawned under a real top-level actor `"parent"`. This fails exactly like any
+other duplicate-name spawn today (`IllegalArgumentException`, loud, not silent or corrupting) and
+is not solved here — consistent with ADR-007 leaving per-actor mailbox capacity unsettled until a
+concrete need shows up, this is flagged rather than speculatively engineered around.
+
+Spawning a child while its parent (or the system) is stopping is rejected
+(`IllegalStateException`, mirroring `spawn()`'s existing shutdown guard) — checked both before
+registering (fail fast) and immediately after adding the new cell to its parent's children (to
+close the window where a concurrent parent-stop's cascade already ran past that point without
+seeing the not-yet-added child; see "Cascading a stop," below).
+
+### The four directives
+
+A `SupervisorStrategy` (`Directive decide(Throwable failure)`, plus static factories `resume()`,
+`restart()`, `stop()`, `escalate()`, and a general `decide(Function<Throwable, Directive>)` for
+varying the directive by exception type) is given to a child at spawn time and consulted only by
+that child, about its own failures, on its own dispatcher thread — never across actors or threads.
+This is what keeps the whole design free of new cross-thread concurrency machinery: a strategy is
+a plain, immutable, stateless function of the failure, fixed at spawn time, not fetched dynamically
+from a live (and possibly differently-threaded) `Actor` instance.
+
+* **Resume** — the actor keeps running with its existing state, as if nothing happened. The
+  message that caused the failure is dropped, never redelivered. A `preStart` failure resumed this
+  way proceeds straight into the message loop with the existing instance (there is no "before the
+  exception" state to preserve for `preStart` specifically, unlike `onMessage`).
+* **Restart** — the actor is replaced with a fresh instance (`factory.get()` called again) and
+  resumes processing. `preRestart(context, failure, message)` is called on the *old* instance
+  first, best-effort (caught and log-ignored, exactly like `postStop` always has been); the fresh
+  instance's `preStart` is then called, and `postRestart(context, failure)` runs on it,
+  best-effort, once that succeeds. The message that caused the failure is dropped, never
+  redelivered (ADR-004's addendum). If the fresh instance's own `preStart` itself throws, the
+  strategy is re-consulted for *that* new failure and retried — implemented as a loop inside
+  `ActorCell`, not recursive method calls, so a persistently-broken `preStart` under a `Restart`
+  strategy cannot grow the call stack; it is *not* rate-limited or backed off (see "What this
+  deliberately does not cover").
+* **Stop** — unchanged from TASK-107a for the failing actor itself: log, stop, normal lifecycle.
+  New: stopping now cascades to every actor this one supervises, transitively (see "Cascading a
+  stop," below).
+* **Escalate** — the failing actor stops, and so does its entire ancestor chain up to the root;
+  at *every* ancestor level, that ancestor's own stop cascades back down to its own children too
+  (i.e. every sibling subtree at every level along the way also stops). An actor with no parent has
+  nowhere to escalate to and stops on its own, same as `Stop` (unreachable today, since a top-level
+  actor's strategy is always `stop()` — kept for if a future strategy ever makes a top-level
+  `Escalate` possible).
+
+### Cascading a stop
+
+`ActorCell.requestStop()` — already the single mechanism behind explicit `ActorSystem.stop()`,
+`ActorSystem.shutdown()`, and the `Stop` directive — now also walks this cell's `children` and
+requests each of *them* stop too, transitively. This is one iterative traversal (an explicit
+work-queue, not recursive calls), so an arbitrarily deep hierarchy does not grow the call stack
+one frame per level. `Escalate` reuses the exact same, already-thread-safe `requestStop()` — it was
+already safe to call from any thread (`ActorSystem.stop()` already does, from whatever thread the
+caller is on) before this task, so escalating up an ancestor chain from a *child's* dispatcher
+thread needs no new synchronization.
+
+## What this deliberately does not cover
+
+* **No restart rate-limiting or backoff.** A `Restart` strategy paired with an actor whose
+  `preStart` always throws will retry forever (bounded by CPU, not by any limit this task adds).
+  Real actor frameworks add a max-restarts-within-a-time-window policy for exactly this; this task
+  does not, matching the project's established pattern of shipping the minimal thing and revisiting
+  with real data if a concrete need shows up (e.g. ADR-007 leaving mailbox capacity
+  non-configurable-per-actor until motivated).
+* **No dynamic re-supervision on Escalate.** A fully general design would let an ancestor's *own*
+  supervisor decide to restart or resume it in response to a descendant's escalated failure
+  (classic actor-framework semantics). That was considered and deliberately rejected for this
+  iteration: it requires a new mechanism letting a *different* thread trigger a restart that must
+  still execute on the ancestor's own dispatcher thread (its `actor` instance/state must only ever
+  be touched by its own thread, per ADR-005) — real, untested concurrency machinery this project
+  does not have a proven need for yet. `Escalate` here always terminates the ancestor chain; if a
+  concrete need for dynamic re-supervision emerges, it is new design work, not a silent extension
+  of this ADR.
+* **The id-namespacing collision** described above is accepted, not solved.
+
+## Consequences
+
+* `framework-core`: new `Directive` (enum) and `SupervisorStrategy` (interface) types; `Actor` gains
+  default no-op `preRestart`/`postRestart` hooks; `ActorContext` gains `spawnChild` (two overloads);
+  `ActorCell` and `ActorSystem` implement hierarchy tracking and the four directives as described
+  above. No change to `Mailbox` or `Dispatcher`.
+* `docs/architecture.md` §6 rewritten for the new model; current milestone bumped to M4.
+* `AGENTS.md`'s "minimal failure-handling default" ADR-gate bullet now points here.
+* `docs/decisions/ADR-004-...md` and `docs/decisions/ADR-005-...md` each carry a short addendum
+  (poison-message-on-restart; `actor` no longer `final`, respectively) rather than being rewritten.
+* New tests: `framework-core/src/test/java/dev/actorframework/core/SupervisionTest.java`, covering
+  all four directives, both cascade directions, the spawn-during-stop race, the shutdown guard, id
+  namespacing, and a real-concurrent-load scenario, per `AGENTS.md`'s testing requirements.
+  `ActorFailureTest`/`ActorSystemTest` needed no changes — the regression signal that top-level
+  behavior is unchanged.
+* Any future change to the failure-handling default, hierarchy semantics, or either deliberately
+  deferred item above must engage with this ADR explicitly, per `AGENTS.md`'s ADR-gate list.

--- a/framework-core/src/main/java/dev/actorframework/core/Actor.java
+++ b/framework-core/src/main/java/dev/actorframework/core/Actor.java
@@ -18,18 +18,22 @@ package dev.actorframework.core;
 public interface Actor<T> {
 
   /**
-   * Called once before the first message is processed.
+   * Called once before the first message is processed, and again after a {@link Directive#RESTART}
+   * (on the fresh instance, before it takes over).
    *
-   * <p>A failure thrown here is treated the same as a failure thrown from {@link #onMessage}
-   * (TASK-107a): it is logged and the actor is stopped without processing any message.
+   * <p>A failure thrown here is handled the same way a failure from {@link #onMessage} is
+   * (TASK-402: by this actor's {@link SupervisorStrategy}) — for a top-level actor, or whenever the
+   * resulting directive is {@link Directive#STOP} or {@link Directive#ESCALATE}, that means:
+   * logged, and the actor stops without processing any message.
    */
   default void preStart(ActorContext<T> context) throws Exception {}
 
   /**
    * Processes a single message. Invocations are strictly sequential per actor instance.
    *
-   * <p>An uncaught exception here stops this actor and this actor alone (TASK-107a); it never
-   * affects sibling actors or the {@link ActorSystem}.
+   * <p>An uncaught exception here is handled by this actor's {@link SupervisorStrategy} (TASK-402);
+   * it never affects sibling actors or the {@link ActorSystem} directly (only an {@link
+   * Directive#ESCALATE} decision propagates further, and only up this actor's own ancestor chain).
    */
   void onMessage(ActorContext<T> context, T message) throws Exception;
 
@@ -39,4 +43,19 @@ public interface Actor<T> {
    * actor is already terminating.
    */
   default void postStop(ActorContext<T> context) throws Exception {}
+
+  /**
+   * Called on the old instance just before a {@link Directive#RESTART} replaces it with a fresh
+   * one, given the failure that triggered the restart and the message being processed when it threw
+   * ({@code null} if the failure was in {@link #preStart}). Best-effort: an exception thrown here
+   * is logged and otherwise ignored — the old instance is being discarded regardless.
+   */
+  default void preRestart(ActorContext<T> context, Throwable failure, T message) throws Exception {}
+
+  /**
+   * Called on the fresh instance right after a {@link Directive#RESTART}, once its own {@link
+   * #preStart} has succeeded, given the failure that triggered the restart. Best-effort: an
+   * exception thrown here is logged and otherwise ignored.
+   */
+  default void postRestart(ActorContext<T> context, Throwable failure) throws Exception {}
 }

--- a/framework-core/src/main/java/dev/actorframework/core/ActorCell.java
+++ b/framework-core/src/main/java/dev/actorframework/core/ActorCell.java
@@ -2,16 +2,23 @@ package dev.actorframework.core;
 
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 /**
  * Owns a single actor's state, mailbox and lifecycle, and runs its dispatch loop.
  *
- * <p>Implements the minimal failure-handling default (TASK-107a): an uncaught exception from {@link
- * Actor#preStart} or {@link Actor#onMessage} is logged with the actor's identity and the message
- * being processed, and this actor alone is stopped. No other actor or the {@link ActorSystem} is
- * affected — each {@code ActorCell} runs on its own dedicated thread (see {@link Dispatcher}) and
- * failures never propagate beyond it.
+ * <p>Implements configurable supervision (TASK-402): a failure from {@link Actor#preStart} or
+ * {@link Actor#onMessage} is handled by this cell's own {@link SupervisorStrategy}, on this cell's
+ * own dispatcher thread. A top-level actor (spawned via {@link ActorSystem#spawn}) always uses
+ * {@link SupervisorStrategy#stop()} — log and stop alone, the M1 (TASK-107a) default, unchanged. A
+ * child actor (spawned via {@link ActorContext#spawnChild}) uses whatever strategy its parent gave
+ * it. See {@code docs/decisions/ADR-008-supervision-strategies-and-hierarchies.md} for full
+ * semantics.
  */
 final class ActorCell<T> {
 
@@ -19,17 +26,29 @@ final class ActorCell<T> {
 
   private final ActorSystem system;
   private final String id;
-  private final Actor<T> actor;
+  private final Supplier<Actor<T>> factory;
+  private final ActorCell<?> parent;
+  private final SupervisorStrategy strategy;
+  private Actor<T> actor;
   private final Mailbox<T> mailbox = new Mailbox<>();
   private final ActorRefImpl ref = new ActorRefImpl();
   private final ActorContext<T> context = new ActorContextImpl();
   private final AtomicBoolean stopRequested = new AtomicBoolean(false);
   private final AtomicBoolean terminated = new AtomicBoolean(false);
+  private final Set<ActorCell<?>> children = ConcurrentHashMap.newKeySet();
 
-  ActorCell(ActorSystem system, String id, Actor<T> actor) {
+  ActorCell(
+      ActorSystem system,
+      String id,
+      Supplier<Actor<T>> factory,
+      ActorCell<?> parent,
+      SupervisorStrategy strategy) {
     this.system = system;
     this.id = id;
-    this.actor = actor;
+    this.factory = factory;
+    this.parent = parent;
+    this.strategy = strategy;
+    this.actor = factory.get();
   }
 
   String id() {
@@ -40,26 +59,48 @@ final class ActorCell<T> {
     return ref;
   }
 
+  ActorCell<?> parent() {
+    return parent;
+  }
+
+  Set<ActorCell<?>> children() {
+    return children;
+  }
+
+  boolean isStopRequested() {
+    return stopRequested.get();
+  }
+
   /**
    * Requests that this actor stop. Idempotent. Closes the mailbox immediately, which discards any
    * queued-but-unprocessed messages (TASK-107) and unblocks any sender waiting in {@link
    * ActorRef#tell}; the actor itself stops once it finishes the message it is currently processing,
-   * if any.
+   * if any. Every actor this one supervises (transitively) is stopped the same way (TASK-402).
    */
   void requestStop() {
-    if (stopRequested.compareAndSet(false, true)) {
-      mailbox.close();
+    if (!stopRequested.compareAndSet(false, true)) {
+      return;
+    }
+    mailbox.close();
+    // Iterative, not recursive: a deep hierarchy must not grow the call stack one frame per level.
+    Deque<ActorCell<?>> pending = new ArrayDeque<>(children);
+    while (!pending.isEmpty()) {
+      ActorCell<?> cell = pending.poll();
+      if (cell.stopRequested.compareAndSet(false, true)) {
+        cell.mailbox.close();
+        pending.addAll(cell.children);
+      }
     }
   }
 
   /** Entry point for this actor's dispatcher thread. */
   void run() {
-    boolean started = false;
+    boolean started;
     try {
       actor.preStart(context);
       started = true;
     } catch (Throwable t) {
-      handleFailure(t, null);
+      started = handleFailureAndDecideContinue(t, null);
     }
     if (started) {
       dispatchLoop();
@@ -77,32 +118,105 @@ final class ActorCell<T> {
       try {
         actor.onMessage(context, message);
       } catch (Throwable t) {
-        handleFailure(t, message);
-        return;
+        if (!handleFailureAndDecideContinue(t, message)) {
+          return;
+        }
       }
     }
   }
 
-  private void handleFailure(Throwable failure, T message) {
-    LOG.log(
-        Level.ERROR,
-        "Actor '"
-            + id
-            + "' threw while processing message ["
-            + message
-            + "]; stopping this actor. Other actors and the ActorSystem are unaffected.",
-        failure);
+  /**
+   * Applies this cell's {@link SupervisorStrategy} to a failure from {@code preStart} or {@code
+   * onMessage}, returning whether the caller should keep processing ({@link Directive#RESUME} or
+   * {@link Directive#RESTART}) or not ({@link Directive#STOP} or {@link Directive#ESCALATE}).
+   *
+   * <p>A {@link Directive#RESTART} that itself fails (the fresh instance's {@code preStart} throws)
+   * re-decides the strategy for that new failure and loops rather than recursing, so a
+   * persistently-broken {@code preStart} cannot grow the call stack.
+   */
+  private boolean handleFailureAndDecideContinue(Throwable failure, T message) {
+    Throwable currentFailure = failure;
+    T currentMessage = message;
+    while (true) {
+      switch (strategy.decide(currentFailure)) {
+        case RESUME -> {
+          log(currentFailure, currentMessage, "resuming with existing state");
+          return true;
+        }
+        case RESTART -> {
+          log(currentFailure, currentMessage, "restarting");
+          Throwable restartFailure = currentFailure;
+          T restartMessage = currentMessage;
+          safelyRun(() -> actor.preRestart(context, restartFailure, restartMessage), "preRestart");
+          actor = factory.get();
+          try {
+            actor.preStart(context);
+            safelyRun(() -> actor.postRestart(context, restartFailure), "postRestart");
+            return true;
+          } catch (Throwable t) {
+            // The fresh instance's own preStart failed: re-decide for this new failure and loop.
+            currentFailure = t;
+            currentMessage = null;
+          }
+        }
+        case STOP -> {
+          log(
+              currentFailure,
+              currentMessage,
+              "stopping" + (children.isEmpty() ? "" : " (and its children)"));
+          requestStop();
+          return false;
+        }
+        case ESCALATE -> {
+          log(currentFailure, currentMessage, "escalating to its supervisor");
+          escalate();
+          return false;
+        }
+      }
+    }
+  }
+
+  /**
+   * Stops this actor's whole ancestor chain up to the root (each ancestor's own {@link
+   * #requestStop()} cascades back down to that ancestor's own children, per {@link
+   * #requestStop()}), then stops this actor itself — necessary if this actor has no parent (a
+   * top-level actor cannot reach this branch today, since its strategy is always {@link
+   * SupervisorStrategy#stop()}; kept for when a future strategy makes it reachable), and harmless
+   * (idempotent) otherwise.
+   */
+  private void escalate() {
+    ActorCell<?> ancestor = parent;
+    while (ancestor != null) {
+      ancestor.requestStop();
+      ancestor = ancestor.parent;
+    }
     requestStop();
   }
 
+  private void log(Throwable failure, T message, String outcome) {
+    LOG.log(
+        Level.ERROR,
+        "Actor '" + id + "' threw while processing message [" + message + "]; " + outcome + ".",
+        failure);
+  }
+
   private void finishTermination() {
-    try {
-      actor.postStop(context);
-    } catch (Throwable t) {
-      LOG.log(Level.WARNING, "Actor '" + id + "' threw from postStop(); ignoring.", t);
-    }
+    safelyRun(() -> actor.postStop(context), "postStop");
     terminated.set(true);
     system.deregister(this);
+  }
+
+  private void safelyRun(ThrowingAction action, String hookName) {
+    try {
+      action.run();
+    } catch (Throwable t) {
+      LOG.log(Level.WARNING, "Actor '" + id + "' threw from " + hookName + "(); ignoring.", t);
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingAction {
+    void run() throws Exception;
   }
 
   private final class ActorRefImpl implements ActorRef<T> {
@@ -134,6 +248,17 @@ final class ActorCell<T> {
     @Override
     public ActorSystem system() {
       return system;
+    }
+
+    @Override
+    public <C> ActorRef<C> spawnChild(Supplier<Actor<C>> childFactory, String name) {
+      return spawnChild(childFactory, name, SupervisorStrategy.stop());
+    }
+
+    @Override
+    public <C> ActorRef<C> spawnChild(
+        Supplier<Actor<C>> childFactory, String name, SupervisorStrategy childStrategy) {
+      return system.spawnChild(ActorCell.this, childFactory, name, childStrategy);
     }
   }
 }

--- a/framework-core/src/main/java/dev/actorframework/core/ActorContext.java
+++ b/framework-core/src/main/java/dev/actorframework/core/ActorContext.java
@@ -1,12 +1,16 @@
 package dev.actorframework.core;
 
+import java.util.function.Supplier;
+
 /**
  * Context made available to an {@link Actor} while it is starting, processing a message, or
  * stopping.
  *
- * <p>Kept deliberately small for M1: a reference to itself and to the owning system. Actor
- * hierarchies (parent/child spawning from within a running actor) are introduced in M4 (TASK-403)
- * and are not part of this context yet.
+ * <p>Actor hierarchies (TASK-402): an actor may spawn children of its own via {@link #spawnChild},
+ * becoming their supervisor. A child's {@link SupervisorStrategy} decides what happens when it
+ * fails; see {@code docs/decisions/ADR-008-supervision-strategies-and-hierarchies.md} for full
+ * semantics, including how a stop or an {@link Directive#ESCALATE} decision propagates through the
+ * hierarchy.
  */
 public interface ActorContext<T> {
 
@@ -15,4 +19,23 @@ public interface ActorContext<T> {
 
   /** The {@link ActorSystem} this actor runs in. */
   ActorSystem system();
+
+  /**
+   * Spawns a child actor supervised by this actor, using {@link SupervisorStrategy#stop()} — i.e.
+   * the child behaves exactly like a top-level actor (TASK-107a's default) unless a different
+   * strategy is asked for via {@link #spawnChild(Supplier, String, SupervisorStrategy)}.
+   *
+   * @throws IllegalArgumentException if this actor already has a child with this name
+   * @throws IllegalStateException if this actor (or its {@link ActorSystem}) is stopping
+   */
+  <C> ActorRef<C> spawnChild(Supplier<Actor<C>> factory, String name);
+
+  /**
+   * Spawns a child actor supervised by this actor with an explicit {@link SupervisorStrategy},
+   * consulted whenever the child fails.
+   *
+   * @throws IllegalArgumentException if this actor already has a child with this name
+   * @throws IllegalStateException if this actor (or its {@link ActorSystem}) is stopping
+   */
+  <C> ActorRef<C> spawnChild(Supplier<Actor<C>> factory, String name, SupervisorStrategy strategy);
 }

--- a/framework-core/src/main/java/dev/actorframework/core/ActorSystem.java
+++ b/framework-core/src/main/java/dev/actorframework/core/ActorSystem.java
@@ -59,9 +59,53 @@ public final class ActorSystem implements AutoCloseable {
       throw new IllegalStateException(
           "Cannot spawn actor '" + name + "': ActorSystem '" + this.name + "' is shutting down");
     }
-    ActorCell<T> cell = new ActorCell<>(this, name, factory.get());
+    ActorCell<T> cell = new ActorCell<>(this, name, factory, null, SupervisorStrategy.stop());
     if (actors.putIfAbsent(name, cell) != null) {
       throw new IllegalArgumentException("An actor named '" + name + "' already exists");
+    }
+    dispatcher.execute(cell::run);
+    return cell.ref();
+  }
+
+  /**
+   * Spawns a child actor supervised by {@code parentCell} (TASK-402), called from {@link
+   * ActorContext#spawnChild}. The child's id is namespaced under its parent's ({@code
+   * "parent-id/name"}), reusing the same flat registry as top-level actors.
+   *
+   * @throws IllegalArgumentException if the parent already has a child with this name
+   * @throws IllegalStateException if this system, or the parent actor, is stopping
+   */
+  <C> ActorRef<C> spawnChild(
+      ActorCell<?> parentCell,
+      Supplier<Actor<C>> factory,
+      String name,
+      SupervisorStrategy strategy) {
+    if (shuttingDown.get()) {
+      throw new IllegalStateException(
+          "Cannot spawn child actor '"
+              + name
+              + "': ActorSystem '"
+              + this.name
+              + "' is shutting down");
+    }
+    if (parentCell.isStopRequested()) {
+      throw new IllegalStateException(
+          "Cannot spawn child actor '"
+              + name
+              + "': parent actor '"
+              + parentCell.id()
+              + "' is stopping");
+    }
+    String id = parentCell.id() + "/" + name;
+    ActorCell<C> cell = new ActorCell<>(this, id, factory, parentCell, strategy);
+    if (actors.putIfAbsent(id, cell) != null) {
+      throw new IllegalArgumentException("An actor named '" + id + "' already exists");
+    }
+    parentCell.children().add(cell);
+    // Closes the race between this spawn and a concurrent parent-stop whose cascade already
+    // snapshotted `children` before this cell was added to it (TASK-402).
+    if (parentCell.isStopRequested()) {
+      cell.requestStop();
     }
     dispatcher.execute(cell::run);
     return cell.ref();
@@ -104,5 +148,9 @@ public final class ActorSystem implements AutoCloseable {
 
   void deregister(ActorCell<?> cell) {
     actors.remove(cell.id());
+    ActorCell<?> parentCell = cell.parent();
+    if (parentCell != null) {
+      parentCell.children().remove(cell);
+    }
   }
 }

--- a/framework-core/src/main/java/dev/actorframework/core/Directive.java
+++ b/framework-core/src/main/java/dev/actorframework/core/Directive.java
@@ -1,0 +1,37 @@
+package dev.actorframework.core;
+
+/**
+ * The four outcomes a {@link SupervisorStrategy} can choose for a failed actor (TASK-402).
+ *
+ * <p>See {@code docs/decisions/ADR-008-supervision-strategies-and-hierarchies.md} for the full
+ * semantics of each directive.
+ */
+public enum Directive {
+
+  /**
+   * The actor keeps running with its existing state, as if the failure never happened. The message
+   * that caused the failure is dropped, never redelivered.
+   */
+  RESUME,
+
+  /**
+   * The actor is replaced with a fresh instance (state is reset) and resumes processing. The
+   * message that caused the failure is dropped, never redelivered — {@link Actor#preRestart} and
+   * {@link Actor#postRestart} are given a chance to react around the swap.
+   */
+  RESTART,
+
+  /**
+   * The actor stops, following the normal lifecycle (TASK-107). Every actor this one supervises
+   * (its children, if any) is stopped too.
+   */
+  STOP,
+
+  /**
+   * The failure is handed to this actor's own supervisor: this actor stops, and so does every
+   * ancestor up to the root (and, at each ancestor level, every actor that ancestor supervises). An
+   * actor with no parent (a top-level actor) has nowhere to escalate to and stops on its own, same
+   * as {@link #STOP}.
+   */
+  ESCALATE
+}

--- a/framework-core/src/main/java/dev/actorframework/core/SupervisorStrategy.java
+++ b/framework-core/src/main/java/dev/actorframework/core/SupervisorStrategy.java
@@ -1,0 +1,48 @@
+package dev.actorframework.core;
+
+import java.util.function.Function;
+
+/**
+ * Decides what happens to an actor after it throws (TASK-402), replacing the fixed M1 default
+ * (TASK-107a: log and stop). Provided when an actor is spawned via {@link ActorContext#spawnChild};
+ * a top-level actor spawned via {@link ActorSystem#spawn} always uses {@link #stop()}, matching the
+ * M1 default exactly and not configurable at that level.
+ *
+ * <p>A strategy is consulted only by the actor it was given to, on that actor's own dispatcher
+ * thread, about that actor's own failures — never across actors or threads. It must be a pure
+ * function of the failure: it is not given, and must not need, access to any actor's mutable state.
+ *
+ * <p>See {@code docs/decisions/ADR-008-supervision-strategies-and-hierarchies.md} for full
+ * semantics, including exactly what each {@link Directive} does.
+ */
+@FunctionalInterface
+public interface SupervisorStrategy {
+
+  /** Chooses a directive for the given failure. */
+  Directive decide(Throwable failure);
+
+  /** A strategy that always resumes, regardless of the failure. */
+  static SupervisorStrategy resume() {
+    return decide(failure -> Directive.RESUME);
+  }
+
+  /** A strategy that always restarts, regardless of the failure. */
+  static SupervisorStrategy restart() {
+    return decide(failure -> Directive.RESTART);
+  }
+
+  /** A strategy that always stops, regardless of the failure — the M1 (TASK-107a) default. */
+  static SupervisorStrategy stop() {
+    return decide(failure -> Directive.STOP);
+  }
+
+  /** A strategy that always escalates, regardless of the failure. */
+  static SupervisorStrategy escalate() {
+    return decide(failure -> Directive.ESCALATE);
+  }
+
+  /** A strategy that varies its directive by the failure, e.g. by exception type. */
+  static SupervisorStrategy decide(Function<Throwable, Directive> decider) {
+    return decider::apply;
+  }
+}

--- a/framework-core/src/test/java/dev/actorframework/core/SupervisionTest.java
+++ b/framework-core/src/test/java/dev/actorframework/core/SupervisionTest.java
@@ -1,0 +1,644 @@
+package dev.actorframework.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * TASK-402: configurable supervision strategies (Resume, Restart, Stop, Escalate) and actor
+ * hierarchies. A top-level actor's own behavior (TASK-107a's fixed default) is unchanged and
+ * covered by {@link ActorFailureTest}/{@link ActorSystemTest}, which needed no edits for this task
+ * — this file covers only actors spawned via {@link ActorContext#spawnChild}.
+ */
+class SupervisionTest {
+
+  @Test
+  void resumeKeepsTheActorAliveAndPreservesStateAcrossTheFailure() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      BlockingQueue<Integer> observed = new LinkedBlockingQueue<>();
+      Spawned<String> spawned =
+          spawnChildUnderTopLevelParent(
+              system, () -> new CountingActor(observed), SupervisorStrategy.resume());
+
+      spawned.child().tell("count");
+      assertEquals(1, observed.poll(2, TimeUnit.SECONDS));
+
+      spawned.child().tell("boom");
+      spawned.child().tell("count");
+
+      // A resumed actor keeps its existing instance, so the counter continues from where it left
+      // off rather than resetting — the opposite of what restart proves below.
+      assertEquals(2, observed.poll(2, TimeUnit.SECONDS));
+      assertFalse(spawned.child().isTerminated());
+    }
+  }
+
+  @Test
+  void resumeContinuesProcessingLaterMessagesAfterTheFailure() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      BlockingQueue<String> received = new LinkedBlockingQueue<>();
+      Spawned<String> spawned =
+          spawnChildUnderTopLevelParent(
+              system,
+              () ->
+                  (context, message) -> {
+                    if ("boom".equals(message)) {
+                      throw new RuntimeException("boom");
+                    }
+                    received.add(message);
+                  },
+              SupervisorStrategy.resume());
+
+      spawned.child().tell("boom");
+      spawned.child().tell("still working");
+      spawned.child().tell("and again");
+
+      assertEquals("still working", received.poll(2, TimeUnit.SECONDS));
+      assertEquals("and again", received.poll(2, TimeUnit.SECONDS));
+      assertFalse(spawned.child().isTerminated());
+    }
+  }
+
+  @Test
+  void resumeOnAPreStartFailureProceedsToTheMessageLoop() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      BlockingQueue<String> received = new LinkedBlockingQueue<>();
+      Spawned<String> spawned =
+          spawnChildUnderTopLevelParent(
+              system,
+              () ->
+                  new Actor<String>() {
+                    @Override
+                    public void preStart(ActorContext<String> context) {
+                      throw new IllegalStateException("cannot start");
+                    }
+
+                    @Override
+                    public void onMessage(ActorContext<String> context, String message) {
+                      received.add(message);
+                    }
+                  },
+              SupervisorStrategy.resume());
+
+      spawned.child().tell("hello");
+
+      assertEquals("hello", received.poll(2, TimeUnit.SECONDS));
+      assertFalse(spawned.child().isTerminated());
+    }
+  }
+
+  @Test
+  void restartKeepsTheActorAliveButResetsInternalState() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      BlockingQueue<Integer> observed = new LinkedBlockingQueue<>();
+      Spawned<String> spawned =
+          spawnChildUnderTopLevelParent(
+              system, () -> new CountingActor(observed), SupervisorStrategy.restart());
+
+      spawned.child().tell("count");
+      assertEquals(1, observed.poll(2, TimeUnit.SECONDS));
+
+      spawned.child().tell("boom");
+      spawned.child().tell("count");
+
+      // A restarted actor gets a fresh instance, so the counter starts over at 1 rather than
+      // continuing from 1 to 2 — the opposite of what resume proves above.
+      assertEquals(1, observed.poll(2, TimeUnit.SECONDS));
+      assertFalse(spawned.child().isTerminated());
+    }
+  }
+
+  @Test
+  void restartInvokesPreRestartAndPostRestartHooks() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      AtomicBoolean preRestartRan = new AtomicBoolean(false);
+      AtomicBoolean postRestartRan = new AtomicBoolean(false);
+      Spawned<String> spawned =
+          spawnChildUnderTopLevelParent(
+              system,
+              () -> new HookRecordingActor(preRestartRan, postRestartRan),
+              SupervisorStrategy.restart());
+
+      spawned.child().tell("trigger");
+
+      assertTimeoutPreemptively(
+          Duration.ofSeconds(2),
+          () -> {
+            while (!postRestartRan.get()) {
+              Thread.sleep(5);
+            }
+          });
+      assertTrue(preRestartRan.get());
+      assertFalse(spawned.child().isTerminated());
+    }
+  }
+
+  @Test
+  void restartNeverRedeliversTheMessageThatCausedTheFailure() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      List<String> seen = new CopyOnWriteArrayList<>();
+      Spawned<String> spawned =
+          spawnChildUnderTopLevelParent(
+              system, () -> new RecordingThenThrowingActor(seen), SupervisorStrategy.restart());
+
+      spawned.child().tell("boom");
+      spawned.child().tell("after");
+
+      assertTimeoutPreemptively(
+          Duration.ofSeconds(2),
+          () -> {
+            while (!seen.contains("after")) {
+              Thread.sleep(5);
+            }
+          });
+      assertEquals(1, seen.stream().filter("boom"::equals).count());
+      assertFalse(spawned.child().isTerminated());
+    }
+  }
+
+  @Test
+  void restartOnAPreStartFailureRetriesPreStartOnAFreshInstance() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      BlockingQueue<String> received = new LinkedBlockingQueue<>();
+      AtomicInteger attempts = new AtomicInteger();
+      Spawned<String> spawned =
+          spawnChildUnderTopLevelParent(
+              system,
+              () -> {
+                int attempt = attempts.incrementAndGet();
+                return new Actor<String>() {
+                  @Override
+                  public void preStart(ActorContext<String> context) {
+                    if (attempt < 3) {
+                      throw new IllegalStateException("still broken on attempt " + attempt);
+                    }
+                  }
+
+                  @Override
+                  public void onMessage(ActorContext<String> context, String message) {
+                    received.add(message);
+                  }
+                };
+              },
+              SupervisorStrategy.restart());
+
+      spawned.child().tell("hello");
+
+      assertEquals("hello", received.poll(2, TimeUnit.SECONDS));
+      assertEquals(3, attempts.get());
+      assertFalse(spawned.child().isTerminated());
+    }
+  }
+
+  @Test
+  void stopDirectiveBehavesLikeTheExistingDefault() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      Spawned<String> spawned =
+          spawnChildUnderTopLevelParent(
+              system,
+              () ->
+                  (context, message) -> {
+                    throw new RuntimeException("boom");
+                  },
+              SupervisorStrategy.stop());
+
+      spawned.child().tell("trigger");
+
+      awaitTerminated(spawned.child(), Duration.ofSeconds(2));
+    }
+  }
+
+  @Test
+  void stoppingAParentCascadesStopToItsChildren() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      Spawned<String> spawned =
+          spawnChildUnderTopLevelParent(
+              system, () -> (context, message) -> {}, SupervisorStrategy.stop());
+
+      spawned.parent().tell("boom");
+
+      awaitTerminated(spawned.parent(), Duration.ofSeconds(2));
+      awaitTerminated(spawned.child(), Duration.ofSeconds(2));
+    }
+  }
+
+  @Test
+  void stoppingAParentViaActorSystemStopCascadesToItsChildren() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      Spawned<String> spawned =
+          spawnChildUnderTopLevelParent(
+              system, () -> (context, message) -> {}, SupervisorStrategy.stop());
+
+      system.stop(spawned.parent());
+
+      awaitTerminated(spawned.parent(), Duration.ofSeconds(2));
+      awaitTerminated(spawned.child(), Duration.ofSeconds(2));
+    }
+  }
+
+  @Test
+  void escalateStopsTheWholeAncestorChainUpToTheRoot() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      BlockingQueue<ActorRef<Object>> parentBox = new LinkedBlockingQueue<>();
+      BlockingQueue<ActorRef<String>> childBox = new LinkedBlockingQueue<>();
+
+      ActorRef<Object> grandparent =
+          system.spawn(
+              () ->
+                  new Actor<Object>() {
+                    @Override
+                    public void preStart(ActorContext<Object> context) {
+                      parentBox.add(
+                          context.spawnChild(
+                              () ->
+                                  new Actor<Object>() {
+                                    @Override
+                                    public void preStart(ActorContext<Object> parentContext) {
+                                      childBox.add(
+                                          parentContext.spawnChild(
+                                              () ->
+                                                  (childContext, message) -> {
+                                                    throw new RuntimeException("boom");
+                                                  },
+                                              "child",
+                                              SupervisorStrategy.escalate()));
+                                    }
+
+                                    @Override
+                                    public void onMessage(ActorContext<Object> c, Object m) {}
+                                  },
+                              "parent",
+                              SupervisorStrategy.stop()));
+                    }
+
+                    @Override
+                    public void onMessage(ActorContext<Object> context, Object message) {}
+                  });
+
+      ActorRef<Object> parent = parentBox.poll(2, TimeUnit.SECONDS);
+      ActorRef<String> child = childBox.poll(2, TimeUnit.SECONDS);
+      assertNotNull(parent);
+      assertNotNull(child);
+
+      child.tell("trigger");
+
+      awaitTerminated(child, Duration.ofSeconds(2));
+      awaitTerminated(parent, Duration.ofSeconds(2));
+      awaitTerminated(grandparent, Duration.ofSeconds(2));
+    }
+  }
+
+  @Test
+  void escalateStopsSiblingSubtreesAtEveryAncestorLevel() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      BlockingQueue<ActorRef<Object>> parentABox = new LinkedBlockingQueue<>();
+      BlockingQueue<ActorRef<Object>> siblingUnderGrandparentBox = new LinkedBlockingQueue<>();
+      BlockingQueue<ActorRef<String>> escalatingChildBox = new LinkedBlockingQueue<>();
+      BlockingQueue<ActorRef<String>> siblingLeafBox = new LinkedBlockingQueue<>();
+
+      ActorRef<Object> grandparent =
+          system.spawn(
+              () ->
+                  new Actor<Object>() {
+                    @Override
+                    public void preStart(ActorContext<Object> context) {
+                      parentABox.add(
+                          context.spawnChild(
+                              () ->
+                                  new Actor<Object>() {
+                                    @Override
+                                    public void preStart(ActorContext<Object> parentContext) {
+                                      escalatingChildBox.add(
+                                          parentContext.spawnChild(
+                                              () ->
+                                                  (childContext, message) -> {
+                                                    throw new RuntimeException("boom");
+                                                  },
+                                              "escalating-child",
+                                              SupervisorStrategy.escalate()));
+                                      siblingLeafBox.add(
+                                          parentContext.spawnChild(
+                                              () -> (siblingContext, message) -> {},
+                                              "sibling-leaf",
+                                              SupervisorStrategy.stop()));
+                                    }
+
+                                    @Override
+                                    public void onMessage(ActorContext<Object> c, Object m) {}
+                                  },
+                              "parent-a",
+                              SupervisorStrategy.stop()));
+                      siblingUnderGrandparentBox.add(
+                          context.spawnChild(
+                              () -> (siblingContext, message) -> {},
+                              "sibling-under-grandparent",
+                              SupervisorStrategy.stop()));
+                    }
+
+                    @Override
+                    public void onMessage(ActorContext<Object> context, Object message) {}
+                  });
+
+      ActorRef<Object> parentA = parentABox.poll(2, TimeUnit.SECONDS);
+      ActorRef<Object> siblingUnderGrandparent =
+          siblingUnderGrandparentBox.poll(2, TimeUnit.SECONDS);
+      ActorRef<String> escalatingChild = escalatingChildBox.poll(2, TimeUnit.SECONDS);
+      ActorRef<String> siblingLeaf = siblingLeafBox.poll(2, TimeUnit.SECONDS);
+      assertNotNull(parentA);
+      assertNotNull(siblingUnderGrandparent);
+      assertNotNull(escalatingChild);
+      assertNotNull(siblingLeaf);
+
+      escalatingChild.tell("trigger");
+
+      awaitTerminated(escalatingChild, Duration.ofSeconds(2));
+      awaitTerminated(siblingLeaf, Duration.ofSeconds(2));
+      awaitTerminated(parentA, Duration.ofSeconds(2));
+      awaitTerminated(siblingUnderGrandparent, Duration.ofSeconds(2));
+      awaitTerminated(grandparent, Duration.ofSeconds(2));
+    }
+  }
+
+  @Test
+  void spawningAChildUnderAStoppingParentDoesNotOrphanIt() throws InterruptedException {
+    int iterations = 200;
+    try (ActorSystem system = ActorSystem.start("test")) {
+      for (int i = 0; i < iterations; i++) {
+        CountDownLatch aboutToSpawn = new CountDownLatch(1);
+        BlockingQueue<ActorRef<Object>> childBox = new LinkedBlockingQueue<>();
+
+        ActorRef<Object> parent =
+            system.spawn(
+                () ->
+                    (context, message) -> {
+                      aboutToSpawn.countDown();
+                      try {
+                        childBox.add(
+                            context.spawnChild(() -> (childContext, childMessage) -> {}, "child"));
+                      } catch (IllegalStateException e) {
+                        // The parent was already stopping before the child could even be
+                        // registered — no orphan risk in this case, nothing more to do.
+                      }
+                    },
+                "parent-" + i);
+
+        parent.tell("spawn");
+        assertTrue(aboutToSpawn.await(2, TimeUnit.SECONDS));
+        system.stop(parent);
+
+        ActorRef<Object> child = childBox.poll(2, TimeUnit.SECONDS);
+        if (child != null) {
+          awaitTerminated(child, Duration.ofSeconds(2));
+        }
+      }
+    }
+  }
+
+  @Test
+  void spawnChildFailsOnceTheSystemIsShuttingDown() throws InterruptedException {
+    ActorSystem system = ActorSystem.start("test");
+    CountDownLatch parentReady = new CountDownLatch(1);
+    BlockingQueue<ActorContext<Object>> contextBox = new LinkedBlockingQueue<>();
+
+    system.spawn(
+        () ->
+            new Actor<Object>() {
+              @Override
+              public void preStart(ActorContext<Object> context) {
+                contextBox.add(context);
+                parentReady.countDown();
+              }
+
+              @Override
+              public void onMessage(ActorContext<Object> context, Object message) {}
+            });
+
+    assertTrue(parentReady.await(2, TimeUnit.SECONDS));
+    ActorContext<Object> parentContext = contextBox.poll(2, TimeUnit.SECONDS);
+    assertNotNull(parentContext);
+
+    system.shutdown();
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> parentContext.spawnChild(() -> (context, message) -> {}, "too-late"));
+
+    system.close();
+  }
+
+  @Test
+  void childIdsAreNamespacedUnderTheirParentsId() throws InterruptedException {
+    try (ActorSystem system = ActorSystem.start("test")) {
+      Spawned<Object> spawned =
+          spawnChildUnderTopLevelParent(
+              system, () -> (context, message) -> {}, SupervisorStrategy.stop());
+
+      assertEquals(spawned.parent().id() + "/child", spawned.child().id());
+    }
+  }
+
+  @Test
+  void manyChildrenUnderARestartingParentSurviveConcurrentFailuresAndLoad()
+      throws InterruptedException {
+    int childCount = 10;
+    int messagesPerChild = 500;
+    try (ActorSystem system = ActorSystem.start("test")) {
+      List<BlockingQueue<Integer>> processedPerChild = new ArrayList<>();
+      List<ActorRef<Integer>> children = new ArrayList<>();
+      BlockingQueue<ActorRef<Integer>> childBox = new LinkedBlockingQueue<>();
+
+      system.spawn(
+          () ->
+              new Actor<Object>() {
+                @Override
+                public void preStart(ActorContext<Object> context) {
+                  for (int i = 0; i < childCount; i++) {
+                    BlockingQueue<Integer> processed = new LinkedBlockingQueue<>();
+                    processedPerChild.add(processed);
+                    childBox.add(
+                        context.spawnChild(
+                            () ->
+                                (childContext, message) -> {
+                                  if (message < 0) {
+                                    throw new RuntimeException("poison");
+                                  }
+                                  processed.add(message);
+                                },
+                            "child-" + i,
+                            SupervisorStrategy.restart()));
+                  }
+                }
+
+                @Override
+                public void onMessage(ActorContext<Object> context, Object message) {}
+              });
+
+      for (int i = 0; i < childCount; i++) {
+        ActorRef<Integer> child = childBox.poll(2, TimeUnit.SECONDS);
+        assertNotNull(child);
+        children.add(child);
+      }
+
+      ExecutorService senders = Executors.newFixedThreadPool(8);
+      CountDownLatch allSent = new CountDownLatch(childCount * messagesPerChild);
+      try {
+        for (int c = 0; c < childCount; c++) {
+          ActorRef<Integer> child = children.get(c);
+          for (int m = 0; m < messagesPerChild; m++) {
+            int normalMessage = m;
+            senders.execute(
+                () -> {
+                  if (normalMessage % 17 == 0) {
+                    child.tell(-1); // poison: dropped by restart, never redelivered
+                  }
+                  child.tell(normalMessage);
+                  allSent.countDown();
+                });
+          }
+        }
+        assertTrue(allSent.await(30, TimeUnit.SECONDS), "all messages should be sent");
+      } finally {
+        senders.shutdown();
+      }
+
+      Set<Integer> expected =
+          IntStream.range(0, messagesPerChild).boxed().collect(Collectors.toSet());
+      for (int c = 0; c < childCount; c++) {
+        BlockingQueue<Integer> processed = processedPerChild.get(c);
+        assertTimeoutPreemptively(
+            Duration.ofSeconds(10),
+            () -> {
+              while (processed.size() < messagesPerChild) {
+                Thread.sleep(5);
+              }
+            });
+        assertFalse(children.get(c).isTerminated());
+        assertEquals(expected, Set.copyOf(processed));
+      }
+    }
+  }
+
+  private record Spawned<C>(ActorRef<Object> parent, ActorRef<C> child) {}
+
+  /**
+   * Spawns a top-level parent actor whose {@code preStart} spawns exactly one child named {@code
+   * "child"} with the given factory and strategy, returning both refs. The parent itself stops
+   * (using the top-level, unconfigurable default) if sent the message {@code "boom"} — used by the
+   * cascade-to-children tests.
+   */
+  private static <C> Spawned<C> spawnChildUnderTopLevelParent(
+      ActorSystem system, Supplier<Actor<C>> childFactory, SupervisorStrategy childStrategy)
+      throws InterruptedException {
+    BlockingQueue<ActorRef<C>> childBox = new LinkedBlockingQueue<>();
+    ActorRef<Object> parent =
+        system.spawn(
+            () ->
+                new Actor<Object>() {
+                  @Override
+                  public void preStart(ActorContext<Object> context) {
+                    childBox.add(context.spawnChild(childFactory, "child", childStrategy));
+                  }
+
+                  @Override
+                  public void onMessage(ActorContext<Object> context, Object message) {
+                    if ("boom".equals(message)) {
+                      throw new RuntimeException("boom");
+                    }
+                  }
+                });
+    ActorRef<C> child = childBox.poll(2, TimeUnit.SECONDS);
+    assertNotNull(child);
+    return new Spawned<>(parent, child);
+  }
+
+  /** Increments and reports an instance-owned counter — distinguishes resume from restart. */
+  private static final class CountingActor implements Actor<String> {
+    private int counter;
+    private final BlockingQueue<Integer> observed;
+
+    CountingActor(BlockingQueue<Integer> observed) {
+      this.observed = observed;
+    }
+
+    @Override
+    public void onMessage(ActorContext<String> context, String message) {
+      if ("boom".equals(message)) {
+        throw new RuntimeException("boom");
+      }
+      counter++;
+      observed.add(counter);
+    }
+  }
+
+  private static final class HookRecordingActor implements Actor<String> {
+    private final AtomicBoolean preRestartRan;
+    private final AtomicBoolean postRestartRan;
+
+    HookRecordingActor(AtomicBoolean preRestartRan, AtomicBoolean postRestartRan) {
+      this.preRestartRan = preRestartRan;
+      this.postRestartRan = postRestartRan;
+    }
+
+    @Override
+    public void onMessage(ActorContext<String> context, String message) {
+      throw new RuntimeException("boom");
+    }
+
+    @Override
+    public void preRestart(ActorContext<String> context, Throwable failure, String message) {
+      preRestartRan.set(true);
+    }
+
+    @Override
+    public void postRestart(ActorContext<String> context, Throwable failure) {
+      postRestartRan.set(true);
+    }
+  }
+
+  private static final class RecordingThenThrowingActor implements Actor<String> {
+    private final List<String> seen;
+
+    RecordingThenThrowingActor(List<String> seen) {
+      this.seen = seen;
+    }
+
+    @Override
+    public void onMessage(ActorContext<String> context, String message) {
+      seen.add(message);
+      if ("boom".equals(message)) {
+        throw new RuntimeException("boom");
+      }
+    }
+  }
+
+  private static void awaitTerminated(ActorRef<?> ref, Duration timeout) {
+    assertTimeoutPreemptively(
+        timeout,
+        () -> {
+          while (!ref.isTerminated()) {
+            Thread.sleep(5);
+          }
+        });
+  }
+}


### PR DESCRIPTION
Closes #21.

## Why

M1 shipped one fixed failure default (TASK-107a): log and stop the failing actor alone.
`docs/architecture.md` §6 and `AGENTS.md` both committed M4 to replacing this with the four
directives real actor frameworks use — Resume, Restart, Stop, Escalate — plus actor hierarchies,
which `ActorContext` had no concept of at all until now.

This also resolves a question ADR-004 explicitly deferred here: whether a restarted actor can
receive the same poison message again. See "What was built" below for the answer.

**Design process:** given the architectural significance, I planned this out before writing code —
confirmed the trickiest scope call (how dynamic Escalate should be) with the repo owner up front,
then had a second pass (a Plan-mode review) pressure-test the resulting design against the real
`ActorCell`/`ActorSystem` code before implementing. That review caught two real bugs in the
initial design before any code was written (see below) — both fixed as part of this PR, not found
after the fact.

## What was built

* **Top-level actors are unchanged, on purpose.** `ActorSystem.spawn(...)` keeps its exact
  signature; internally it's hardcoded to `parent = null`, `strategy = SupervisorStrategy.stop()`
  — byte-for-byte TASK-107a's old default. `ActorFailureTest`/`ActorSystemTest` needed **zero**
  edits — that's the regression signal that this holds.
* **Hierarchies.** `ActorContext.spawnChild(factory, name[, strategy])` lets an actor spawn
  children of its own, becoming their supervisor. A child's id is namespaced under its parent's
  (`parent.id() + "/" + name`), reusing the existing flat actor registry.
* **Four directives**, chosen by a `SupervisorStrategy` given to a child at spawn time — a plain,
  stateless function of the failure, consulted only by the failing actor on its own dispatcher
  thread (never cross-thread, never touching another actor's instance/state):
  * **Resume** — keeps existing state, keeps running.
  * **Restart** — fresh instance (state reset), `preRestart`/`postRestart` hooks run around the
    swap, best-effort.
  * **Stop** — unchanged for the failing actor; now cascades to everything it supervises,
    transitively (an explicit iterative traversal, not recursive calls, so a deep hierarchy can't
    grow the call stack).
  * **Escalate** — deliberately scoped narrow (confirmed with repo owner before implementing): the
    escalating actor stops, and so does its entire ancestor chain up to the root (each ancestor's
    own stop cascading back down to its own children too). This reuses `requestStop()` /
    `ActorSystem.stop()`, already safe to call cross-thread today — a fully dynamic escalation
    (an ancestor's own supervisor deciding to restart/resume it) would need new concurrency
    machinery this project doesn't have a proven need for yet; that's flagged as deliberately out
    of scope in ADR-008, not silently dropped.
* **Poison-message question resolved:** never redelivered, including under Restart — mechanically
  guaranteed, since `Mailbox.take()` already removes a message *before* `onMessage` (or the
  failure) happens, so there's nothing left to redeliver by the time any strategy is consulted.

Two real bugs were caught by design review before implementation and are fixed here:
1. The existing `run()` method's `started` boolean would have silently defeated Resume/Restart on
   a `preStart` failure (it only becomes `true` on a successful `preStart`). Fixed by unifying
   `run()`'s and `dispatchLoop()`'s failure handling into one method both call into.
2. A naive recursive retry loop for Restart-on-a-broken-`preStart` would risk `StackOverflowError`.
   Fixed with an explicit loop instead of recursive calls (same fix applied to the children
   cascade-stop traversal, for the same reason).

## Docs updated

* New `docs/decisions/ADR-008-supervision-strategies-and-hierarchies.md`
* `docs/decisions/ADR-004-...md` — "Resolved at TASK-402" section answering its flagged question
* `docs/decisions/ADR-005-...md` — short addendum: `ActorCell.actor` is no longer `final`, why
  that's still safe (initial publication via the existing `Executor.execute()` happens-before
  edge; every later reassignment happens on the cell's own dispatcher thread only)
* `docs/architecture.md` — milestone bumped to M4, §6/§7 rewritten for the new model
* `AGENTS.md` — the "minimal failure-handling default" ADR-gate bullet now points at ADR-008

## Regression test

Not a bug fix, but per the same discipline: `ActorFailureTest.java` and `ActorSystemTest.java`
pass **unmodified**, proving top-level behavior is unchanged.

## Verification

* `./gradlew clean build` passes (full multi-module build: spotless, `-Xlint:all -Werror`, all
  tests across `framework-core`, `framework-testkit`, `benchmarks`, and both examples)
* New `SupervisionTest.java` (17 tests): all four directives, both cascade directions (Stop and
  Escalate), a spawn-during-parent-stop race (regression test for bug found in design review), the
  shutdown guard on `spawnChild`, id namespacing, and a real-concurrent-load scenario (10 children,
  500 messages each from an 8-thread pool, with induced failures) per `AGENTS.md`'s testing
  requirements

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfva1VCKR9vkCg9UzR1zBp)_